### PR TITLE
移除宏包手册 PDF 标题中的冗余字符

### DIFF
--- a/gbt7714.dtx
+++ b/gbt7714.dtx
@@ -26,6 +26,7 @@
 \usepackage{caption}
 \usepackage{booktabs}
 \usepackage{gbt7714}
+\usepackage{hologo}
 \usepackage{listings}
 \makeatletter
 \hypersetup{allcolors=blue}
@@ -78,7 +79,7 @@
 %
 % \GetFileInfo{gbt7714.sty}
 %
-% \title{GB/T 7714 \BibTeX{} style}
+% \title{GB/T 7714 \hologo{BibTeX} style}
 % \author{Zeping Lee\thanks{zepinglee AT gmail.com}}
 % \date{\filedate\qquad\fileversion}
 % \maketitle


### PR DESCRIPTION
看手册时注意到标题栏多了一些无效字符（图中下方窗口），使用 `hologo` 修复了一下。

![图片](https://user-images.githubusercontent.com/63113546/182659149-e1aaab9a-80eb-45e4-b2fe-ac3d3f80deda.png)
