### PR TITLE
Fix and update CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   Test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       # If we want to force regeneration of the cache, increase the number after
       # *both* instances of "texlive-v"
       - name: Load cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/texlive
           key: texlive-v1-${{ steps.get-id.outputs.id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,7 @@ jobs:
       - name: Generate unique ID
         id: get-id
         run: |
-          echo -n ::set-output name=id::
-          cat /proc/sys/kernel/random/uuid
+          echo "id=$(cat /proc/sys/kernel/random/uuid)" >> $GITHUB_OUTPUT
       # Actually load the cache. Since we never reuse the key, we need restore-keys
       # to indicate the prefix of our caches. This loads the newest cache with this
       # prefix in the key.

--- a/test/testfiles-bibunits/package-bibunits.tlg
+++ b/test/testfiles-bibunits/package-bibunits.tlg
@@ -31,7 +31,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write2{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline \ETC.}
+...\write2{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {1}Foo}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 9.913 plus 0.86198
 ...\glue(\parskip) 0.0 plus 1.0
@@ -165,7 +165,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write2{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline \ETC.}
+...\write2{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {2}Bar}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 9.913 plus 0.86198
 ...\glue(\parskip) 0.0 plus 1.0

--- a/test/testfiles-chapterbib/package-chapterbib.tlg
+++ b/test/testfiles-chapterbib/package-chapterbib.tlg
@@ -30,7 +30,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write2{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline \ETC.}
+...\write2{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {1}Foo}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 9.913 plus 0.86198
 ...\glue(\parskip) 0.0 plus 1.0
@@ -172,7 +172,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write2{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline \ETC.}
+...\write2{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {2}Bar}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 9.913 plus 0.86198
 ...\glue(\parskip) 0.0 plus 1.0


### PR DESCRIPTION
- Fix `l3build check` failure caused by enlarged default value for `maxprintline` (from `79` to `9999`)
  see https://github.com/latex3/l3build/blob/main/CHANGELOG.md\#2023-03-22
- Update workflow rule for deprecated GitHub Actions commands `set-output` and env Node 12
- Change `on.pull_request.branches: [main]` to `on.pull_request.branches: [master]` because current repo uses `master` as default branch, and there's no `main` branch

Before: Workflow run failed with 2 warnings (see failed workflow run https://github.com/muzimuzhi/gbt7714-bibtex-style/actions/runs/4636467931/attempts/1)
![image](https://user-images.githubusercontent.com/6376638/230580177-871d76d7-a75f-4e52-86b3-48c7060b34de.png)
After: Workflow run passed with 0 warnings.