### PR TITLE
Change \DescribeEnv into \DescribeOption

### DIFF
--- a/gbt7714.dtx
+++ b/gbt7714.dtx
@@ -170,7 +170,7 @@
 % 著者-出版年制通常不需要修改引用样式。
 % \end{function}
 %
-% \DescribeEnv{sort\&compress}
+% \DescribeOption{sort\&compress}
 % 同一处引用多篇文献时，应当将各篇文献的 key 一同写在 \cs{cite} 命令中。
 % 如遇连续编号，默认会自动转为起讫序号并用短横线连接
 % （见\pkg{natbib} 的 \opt{compress} 选项）。


### PR DESCRIPTION
`l3doc.cls` 里定义了针对选项的 Doc Element:
```tex
\NewDocElement[idxtype = option, idxgroup = options]{Option}{optionenv}
```
所以对于 `sort\&compress`，使用 `\DescribeOption` 更符合语义。手册里的 (*env.*) 也就自然去除了。