### PR TITLE
Fix issue 145 and 172

### DIFF
--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -42,5 +42,6 @@ latexmk
 listings
 makeindex
 psnfss
+tex-gyre
 underscore
 xcolor

--- a/gbt7714-2005-author-year.bst
+++ b/gbt7714-2005-author-year.bst
@@ -44,7 +44,6 @@ INTEGERS {
   show.missing.address.publisher
   space.before.pages
   only.start.page
-  wave.dash.in.pages
   show.urldate
   show.url
   show.doi
@@ -52,6 +51,7 @@ INTEGERS {
   show.note
   show.english.translation
   end.with.period
+  lowercase.word.after.colon
   lang.zh.order
   lang.ja.order
   lang.en.order
@@ -61,6 +61,7 @@ INTEGERS {
 
 STRINGS {
   component.part.label
+  page.range.delimiter
 }
 
 FUNCTION {load.config}
@@ -89,7 +90,7 @@ FUNCTION {load.config}
   #0 'show.missing.address.publisher :=
   #1 'space.before.pages :=
   #0 'only.start.page :=
-  #0 'wave.dash.in.pages :=
+  "-" 'page.range.delimiter :=
   #1 'show.urldate :=
   #1 'show.url :=
   #0 'show.doi :=
@@ -97,6 +98,7 @@ FUNCTION {load.config}
   #0 'show.note :=
   #0 'show.english.translation :=
   #1 'end.with.period :=
+  #1 'lowercase.word.after.colon :=
   #1 'lang.zh.order :=
   #2 'lang.ja.order :=
   #3 'lang.en.order :=
@@ -243,6 +245,14 @@ FUNCTION {bbl.sine.loco.sine.nomine}
     { "[S.l.: s.n.]" }
   if$
 }
+
+FUNCTION {default.self.tokens} { ":,-'–—?.!" }
+
+FUNCTION {latin.upper} { "ÀÁÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİIĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ" }
+
+FUNCTION {latin.lower} { "àáãäåæçèéêëìíîïðñòóôõöøùúûüýþÿāăąćĉċčďđēĕėęěĝğġģĥħĩīĭįiıĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" }
+
+FUNCTION {range.delimiters} { "-–—～" }
 
 FUNCTION {not}
 {   { #0 }
@@ -449,6 +459,619 @@ FUNCTION {new.sentence.checkb}
   if$
 }
 
+INTEGERS { b }
+
+FUNCTION {is.int.in.range}
+{
+  'b :=
+  #1 +
+  b >
+    { #1 - b < }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {mult.power2}
+{
+  { duplicate$ #0 > }
+    {
+      swap$
+      duplicate$ +
+      swap$ #1 -
+    }
+  while$
+  pop$
+}
+
+FUNCTION {find.match.brace}
+{
+  's :=
+  't :=
+
+  #1
+  { duplicate$ #0 >
+    s empty$ not and }
+    {
+      s #1 #1 substring$ "{" =
+        { #1 + }
+        {
+          s #1 #1 substring$ "}" =
+            { #1 - }
+            'skip$
+          if$
+        }
+      if$
+      t s #1 #1 substring$ * 't :=
+      s #2 global.max$ substring$ 's :=
+    }
+  while$
+
+  duplicate$ #0 >
+    {
+      "Unbalanced brace(s): one or more closing braces are missing" warning$
+      { duplicate$ #0 > }
+        {
+          t "}" * 't :=
+          #1 -
+        }
+      while$
+    }
+    'skip$
+  if$
+  pop$
+
+  t
+  s
+}
+
+FUNCTION {split.first.char.from.str}
+{
+  duplicate$ "" =
+    {
+      "split.first.char.from.str: Trying to split an empty string!" warning$
+      ""
+    }
+    {
+      duplicate$ #1 #1 substring$ chr.to.int$ #128 <
+        {
+          duplicate$ #1 #1 substring$ swap$
+          #2 global.max$ substring$ swap$
+        }
+        {
+          duplicate$ #1 #1 substring$ chr.to.int$ #224 <
+            {
+              duplicate$ #1 #2 substring$ swap$
+              #3 global.max$ substring$ swap$
+            }
+            {
+              duplicate$ #1 #1 substring$ chr.to.int$ #240 <
+                {
+                  duplicate$ #1 #3 substring$ swap$
+                  #4 global.max$ substring$ swap$
+                }
+                {
+                  duplicate$ #1 #4 substring$ swap$
+                  #5 global.max$ substring$ swap$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {get.first.char.from.str}
+{
+  split.first.char.from.str swap$ pop$
+}
+
+FUNCTION {split.first.tex.char.from.str}
+{
+  duplicate$ #1 #1 substring$ "{" =
+    {
+      split.first.char.from.str swap$
+      find.match.brace swap$
+    }
+    'split.first.char.from.str
+  if$
+}
+
+FUNCTION {char.to.unicode}
+{
+  duplicate$ #4 #1 substring$ "" =
+    {
+      duplicate$ #3 #1 substring$ "" =
+        {
+          duplicate$ #2 #1 substring$ "" =
+            {
+              duplicate$ "" =
+                {
+                  "Empty string is not a char!" warning$
+                  pop$ #-1
+                }
+                { #1 #1 substring$ chr.to.int$ }
+              if$
+            }
+            {
+              duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+              #1 #1 substring$ chr.to.int$ #192 -
+              #6 mult.power2 +
+            }
+          if$
+        }
+        {
+          duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+          duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+          #1 #1 substring$ chr.to.int$ #224 -
+          #6 mult.power2 +
+          #6 mult.power2 +
+        }
+      if$
+    }
+    {
+      duplicate$ #4 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+      #1 #1 substring$ chr.to.int$ #240 -
+      #6 mult.power2 +
+      #6 mult.power2 +
+      #6 mult.power2 +
+    }
+  if$
+}
+
+FUNCTION {is.char.in.str}
+{
+  't :=
+
+  t "" =
+    { "is.char.in.str: Empty string is not a char!" warning$ }
+    'skip$
+  if$
+
+  #0 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str t =
+        { pop$ pop$ #1 "" }
+        'skip$
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.upper.ascii}
+{
+  char.to.unicode #65 swap$ #90 swap$ is.int.in.range
+}
+
+FUNCTION {is.upper}
+{
+  duplicate$ is.upper.ascii
+    { pop$ #1 }
+    { latin.upper swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.lower.ascii}
+{
+  char.to.unicode #97 swap$ #122 swap$ is.int.in.range
+}
+
+FUNCTION {is.lower}
+{
+  duplicate$ is.lower.ascii
+    { pop$ #1 }
+    { latin.lower swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.printable.ascii}
+{
+  char.to.unicode #32 swap$ #126 swap$ is.int.in.range
+}
+
+FUNCTION {is.letter.ascii}
+{
+  duplicate$ is.upper.ascii swap$ is.lower.ascii or
+}
+
+FUNCTION {is.symbol.ascii}
+{
+  duplicate$ is.printable.ascii swap$ is.letter.ascii not and
+}
+
+FUNCTION {is.all.lower}
+{
+  #1 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str is.lower
+        'skip$
+        { pop$ pop$ #0 "" }
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.tex.str.in.title.case}
+{
+  duplicate$ "" =
+    { pop$ #0 }
+    {
+      split.first.tex.char.from.str purify$
+      duplicate$ "" =
+        { pop$ pop$ #0 }
+        {
+          split.first.char.from.str is.upper
+            {
+              duplicate$ is.all.lower
+                {
+                  empty$
+                    {
+                      duplicate$ "" =
+                        { pop$ #0 }
+                        'is.all.lower
+                      if$
+                    }
+                    'is.all.lower
+                  if$
+                }
+                { pop$ pop$ #0 }
+              if$
+            }
+            { pop$ pop$ #0}
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {is.in.inter.token.chars}
+{
+  duplicate$ #0 =
+    { pop$ " " = }
+    {
+      #1 =
+        { " " range.delimiters * swap$ is.char.in.str }
+        'is.letter.ascii
+      if$
+    }
+  if$
+}
+
+FUNCTION {skip.inter.token.chars.by}
+{
+  'b :=
+  't :=
+
+  "" t
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str
+      duplicate$ b is.in.inter.token.chars
+        { swap$ 't := * t }
+        { swap$ * 't := "" }
+      if$
+    }
+  while$
+
+  pop$ t
+}
+
+FUNCTION {skip.inter.token.chars}
+{
+  #0 skip.inter.token.chars.by
+}
+
+FUNCTION {skip.inter.token.command}
+{
+  duplicate$ "" =
+    { "" }
+    {
+      duplicate$ #1 #1 substring$ is.symbol.ascii
+        { split.first.char.from.str swap$ }
+        { #2 skip.inter.token.chars.by }
+     if$
+    }
+  if$
+}
+
+FUNCTION {is.special.char.command}
+{
+  #2 global.max$ substring$ skip.inter.token.command
+
+  empty$
+    'skip$
+    { "is.special.char.command: cmdstr has extra components!" warning$ }
+  if$
+
+  duplicate$ duplicate$ duplicate$ duplicate$ duplicate$ duplicate$
+  "oOlLij" swap$ is.char.in.str
+  swap$ "oe" = or
+  swap$ "OE" = or
+  swap$ "ae" = or
+  swap$ "AE" = or
+  swap$ "aa" = or
+  swap$ "AA" = or
+}
+
+FUNCTION {map.char}
+{
+  't :=
+  split.first.char.from.str
+  { swap$ duplicate$ "" = not }
+    {
+      swap$ t =
+        { pop$ "" t }
+        {
+          swap$ split.first.char.from.str pop$ swap$
+          split.first.char.from.str
+        }
+      if$
+    }
+  while$
+  pop$ t =
+    'get.first.char.from.str
+    { pop$ t }
+  if$
+}
+
+FUNCTION {to.lower}
+{
+  duplicate$ is.upper.ascii
+    { chr.to.int$ #32 + int.to.chr$ }
+    { latin.lower swap$ latin.upper swap$ map.char }
+  if$
+}
+
+FUNCTION {to.upper}
+{
+  duplicate$ is.lower.ascii
+    { chr.to.int$ #32 - int.to.chr$ }
+    { latin.upper swap$ latin.lower swap$ map.char }
+  if$
+}
+
+FUNCTION {all.to.lower}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.lower swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.lower}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+          duplicate$ is.special.char.command
+            'all.to.lower
+            'skip$
+          if$
+        }
+        'to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.lower}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+        {
+          split.first.char.from.str
+          duplicate$ #92 int.to.chr$ =
+            {
+              swap$ skip.inter.token.command 't := * t
+              swap$ command.to.lower
+            }
+            'to.lower
+          if$
+          swap$ 't := * t
+        }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {all.to.upper}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.upper swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.upper}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+           duplicate$ is.special.char.command
+             'all.to.upper
+             'skip$
+           if$
+        }
+        'to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.upper}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+      {
+        split.first.char.from.str
+        duplicate$ #92 int.to.chr$ =
+          {
+            swap$ skip.inter.token.command 't := * t
+            swap$ command.to.upper
+          }
+          'to.upper
+        if$
+        swap$ 't := * t
+      }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {lower.token.if.in.title.case}
+{
+  duplicate$ is.tex.str.in.title.case
+    { split.first.tex.char.from.str tex.to.lower swap$ * }
+    'skip$
+  if$
+}
+
+FUNCTION {self.tokens}
+{
+  #0 =
+    'default.self.tokens
+    'range.delimiters
+  if$
+}
+
+FUNCTION {tokenize.by}
+{
+  'b :=
+  's :=
+
+  s "" =
+    { "" "" }
+    {
+      s split.first.char.from.str
+      duplicate$ b self.tokens swap$ is.char.in.str
+        'swap$
+        {
+          duplicate$ #92 int.to.chr$ =
+            { swap$ skip.inter.token.command 's := * s }
+            {
+              pop$ pop$ "" s
+              { duplicate$ "" = not }
+                {
+                  split.first.char.from.str
+                  duplicate$ "\ " b self.tokens * swap$ is.char.in.str
+                    { pop$ pop$ "" }
+                    {
+                      duplicate$ "{" =
+                        { swap$ find.match.brace }
+                        'swap$
+                      if$
+                      's := * s
+                    }
+                  if$
+                }
+              while$
+              pop$ s
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tokenize}
+{
+  #0 tokenize.by
+}
+
+FUNCTION {smart.sentence.case}
+{
+  tokenize 's :=
+
+  { s "" = not }
+    {
+      s skip.inter.token.chars 's := * s
+      tokenize swap$
+      duplicate$ ":" =
+        {
+          swap$ 's := *
+          s skip.inter.token.chars 's := * s
+          tokenize swap$
+          lowercase.word.after.colon
+            {
+              duplicate$ "A" =
+                { pop$ "a" }
+                'lower.token.if.in.title.case
+              if$
+            }
+            'skip$
+          if$
+        }
+        'lower.token.if.in.title.case
+      if$
+      swap$ 's := *
+    }
+  while$
+}
+
+FUNCTION {smart.upper.case}
+{
+  s swap$ t swap$
+
+  "" swap$
+  { duplicate$ "" = not }
+    {
+      tokenize swap$
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        'command.to.upper
+        {
+          "" swap$
+          { duplicate$ "" = not }
+            {
+              split.first.tex.char.from.str tex.to.upper
+              swap$ 't := * t
+            }
+          while$
+          pop$
+        }
+      if$
+      swap$ 't := * t
+      skip.inter.token.chars 't := * t
+    }
+  while$
+  pop$
+
+  swap$ 't :=
+  swap$ 's :=
+}
+
 FUNCTION {field.or.null}
 { duplicate$ empty$
     { pop$ "" }
@@ -604,7 +1227,7 @@ FUNCTION {format.name}
       name.lang lang.en =
         { t #1 "{vv~}{ll}{ f{~}}" format.name$
           uppercase.name
-            { "u" change.case$ }
+            'smart.upper.case
             'skip$
           if$
           t #1 "{, jj}" format.name$ *
@@ -783,7 +1406,7 @@ FUNCTION {output.bibitem}
 
 FUNCTION {change.sentence.case}
 { entry.lang lang.en =
-    { "t" change.case$ }
+    'smart.sentence.case
     'skip$
   if$
 }
@@ -1393,32 +2016,27 @@ FUNCTION {format.urldate}
   if$
 }
 
-FUNCTION {hyphenate}
-{ 't :=
-  ""
-    { t empty$ not }
-    { t #1 #1 substring$ "-" =
-        { wave.dash.in.pages
-            { "～" * }
-            { "-" * }
-          if$
-            { t #1 #1 substring$ "-" = }
-            { t #2 global.max$ substring$ 't := }
-          while$
-        }
-        { t #1 #1 substring$ *
-          t #2 global.max$ substring$ 't :=
-        }
+FUNCTION {normalize.page.range}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    {
+      #1 skip.inter.token.chars.by 't :=
+      empty$
+        { "" }
+        'page.range.delimiter
       if$
+      * t
+      #1 tokenize.by 't :=
+      * t
     }
   while$
+  pop$
 }
 
 FUNCTION {format.pages}
-{ pages empty$
-    { "" }
-    { pages hyphenate }
-  if$
+{
+  pages normalize.page.range
 }
 
 FUNCTION {format.extracted.pages}
@@ -1426,8 +2044,8 @@ FUNCTION {format.extracted.pages}
     { "" }
     { pages
       only.start.page
-        'extract.before.dash
-        'hyphenate
+        { #1 tokenize.by pop$ }
+        'normalize.page.range
       if$
     }
   if$

--- a/gbt7714-2005-numerical.bst
+++ b/gbt7714-2005-numerical.bst
@@ -44,7 +44,6 @@ INTEGERS {
   show.missing.address.publisher
   space.before.pages
   only.start.page
-  wave.dash.in.pages
   show.urldate
   show.url
   show.doi
@@ -52,10 +51,12 @@ INTEGERS {
   show.note
   show.english.translation
   end.with.period
+  lowercase.word.after.colon
 }
 
 STRINGS {
   component.part.label
+  page.range.delimiter
 }
 
 FUNCTION {load.config}
@@ -84,7 +85,7 @@ FUNCTION {load.config}
   #0 'show.missing.address.publisher :=
   #1 'space.before.pages :=
   #0 'only.start.page :=
-  #0 'wave.dash.in.pages :=
+  "-" 'page.range.delimiter :=
   #1 'show.urldate :=
   #1 'show.url :=
   #0 'show.doi :=
@@ -92,6 +93,7 @@ FUNCTION {load.config}
   #0 'show.note :=
   #0 'show.english.translation :=
   #1 'end.with.period :=
+  #1 'lowercase.word.after.colon :=
 }
 
 ENTRY
@@ -233,6 +235,14 @@ FUNCTION {bbl.sine.loco.sine.nomine}
     { "[S.l.: s.n.]" }
   if$
 }
+
+FUNCTION {default.self.tokens} { ":,-'–—?.!" }
+
+FUNCTION {latin.upper} { "ÀÁÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİIĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ" }
+
+FUNCTION {latin.lower} { "àáãäåæçèéêëìíîïðñòóôõöøùúûüýþÿāăąćĉċčďđēĕėęěĝğġģĥħĩīĭįiıĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" }
+
+FUNCTION {range.delimiters} { "-–—～" }
 
 FUNCTION {not}
 {   { #0 }
@@ -439,6 +449,619 @@ FUNCTION {new.sentence.checkb}
   if$
 }
 
+INTEGERS { b }
+
+FUNCTION {is.int.in.range}
+{
+  'b :=
+  #1 +
+  b >
+    { #1 - b < }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {mult.power2}
+{
+  { duplicate$ #0 > }
+    {
+      swap$
+      duplicate$ +
+      swap$ #1 -
+    }
+  while$
+  pop$
+}
+
+FUNCTION {find.match.brace}
+{
+  's :=
+  't :=
+
+  #1
+  { duplicate$ #0 >
+    s empty$ not and }
+    {
+      s #1 #1 substring$ "{" =
+        { #1 + }
+        {
+          s #1 #1 substring$ "}" =
+            { #1 - }
+            'skip$
+          if$
+        }
+      if$
+      t s #1 #1 substring$ * 't :=
+      s #2 global.max$ substring$ 's :=
+    }
+  while$
+
+  duplicate$ #0 >
+    {
+      "Unbalanced brace(s): one or more closing braces are missing" warning$
+      { duplicate$ #0 > }
+        {
+          t "}" * 't :=
+          #1 -
+        }
+      while$
+    }
+    'skip$
+  if$
+  pop$
+
+  t
+  s
+}
+
+FUNCTION {split.first.char.from.str}
+{
+  duplicate$ "" =
+    {
+      "split.first.char.from.str: Trying to split an empty string!" warning$
+      ""
+    }
+    {
+      duplicate$ #1 #1 substring$ chr.to.int$ #128 <
+        {
+          duplicate$ #1 #1 substring$ swap$
+          #2 global.max$ substring$ swap$
+        }
+        {
+          duplicate$ #1 #1 substring$ chr.to.int$ #224 <
+            {
+              duplicate$ #1 #2 substring$ swap$
+              #3 global.max$ substring$ swap$
+            }
+            {
+              duplicate$ #1 #1 substring$ chr.to.int$ #240 <
+                {
+                  duplicate$ #1 #3 substring$ swap$
+                  #4 global.max$ substring$ swap$
+                }
+                {
+                  duplicate$ #1 #4 substring$ swap$
+                  #5 global.max$ substring$ swap$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {get.first.char.from.str}
+{
+  split.first.char.from.str swap$ pop$
+}
+
+FUNCTION {split.first.tex.char.from.str}
+{
+  duplicate$ #1 #1 substring$ "{" =
+    {
+      split.first.char.from.str swap$
+      find.match.brace swap$
+    }
+    'split.first.char.from.str
+  if$
+}
+
+FUNCTION {char.to.unicode}
+{
+  duplicate$ #4 #1 substring$ "" =
+    {
+      duplicate$ #3 #1 substring$ "" =
+        {
+          duplicate$ #2 #1 substring$ "" =
+            {
+              duplicate$ "" =
+                {
+                  "Empty string is not a char!" warning$
+                  pop$ #-1
+                }
+                { #1 #1 substring$ chr.to.int$ }
+              if$
+            }
+            {
+              duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+              #1 #1 substring$ chr.to.int$ #192 -
+              #6 mult.power2 +
+            }
+          if$
+        }
+        {
+          duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+          duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+          #1 #1 substring$ chr.to.int$ #224 -
+          #6 mult.power2 +
+          #6 mult.power2 +
+        }
+      if$
+    }
+    {
+      duplicate$ #4 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+      #1 #1 substring$ chr.to.int$ #240 -
+      #6 mult.power2 +
+      #6 mult.power2 +
+      #6 mult.power2 +
+    }
+  if$
+}
+
+FUNCTION {is.char.in.str}
+{
+  't :=
+
+  t "" =
+    { "is.char.in.str: Empty string is not a char!" warning$ }
+    'skip$
+  if$
+
+  #0 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str t =
+        { pop$ pop$ #1 "" }
+        'skip$
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.upper.ascii}
+{
+  char.to.unicode #65 swap$ #90 swap$ is.int.in.range
+}
+
+FUNCTION {is.upper}
+{
+  duplicate$ is.upper.ascii
+    { pop$ #1 }
+    { latin.upper swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.lower.ascii}
+{
+  char.to.unicode #97 swap$ #122 swap$ is.int.in.range
+}
+
+FUNCTION {is.lower}
+{
+  duplicate$ is.lower.ascii
+    { pop$ #1 }
+    { latin.lower swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.printable.ascii}
+{
+  char.to.unicode #32 swap$ #126 swap$ is.int.in.range
+}
+
+FUNCTION {is.letter.ascii}
+{
+  duplicate$ is.upper.ascii swap$ is.lower.ascii or
+}
+
+FUNCTION {is.symbol.ascii}
+{
+  duplicate$ is.printable.ascii swap$ is.letter.ascii not and
+}
+
+FUNCTION {is.all.lower}
+{
+  #1 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str is.lower
+        'skip$
+        { pop$ pop$ #0 "" }
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.tex.str.in.title.case}
+{
+  duplicate$ "" =
+    { pop$ #0 }
+    {
+      split.first.tex.char.from.str purify$
+      duplicate$ "" =
+        { pop$ pop$ #0 }
+        {
+          split.first.char.from.str is.upper
+            {
+              duplicate$ is.all.lower
+                {
+                  empty$
+                    {
+                      duplicate$ "" =
+                        { pop$ #0 }
+                        'is.all.lower
+                      if$
+                    }
+                    'is.all.lower
+                  if$
+                }
+                { pop$ pop$ #0 }
+              if$
+            }
+            { pop$ pop$ #0}
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {is.in.inter.token.chars}
+{
+  duplicate$ #0 =
+    { pop$ " " = }
+    {
+      #1 =
+        { " " range.delimiters * swap$ is.char.in.str }
+        'is.letter.ascii
+      if$
+    }
+  if$
+}
+
+FUNCTION {skip.inter.token.chars.by}
+{
+  'b :=
+  't :=
+
+  "" t
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str
+      duplicate$ b is.in.inter.token.chars
+        { swap$ 't := * t }
+        { swap$ * 't := "" }
+      if$
+    }
+  while$
+
+  pop$ t
+}
+
+FUNCTION {skip.inter.token.chars}
+{
+  #0 skip.inter.token.chars.by
+}
+
+FUNCTION {skip.inter.token.command}
+{
+  duplicate$ "" =
+    { "" }
+    {
+      duplicate$ #1 #1 substring$ is.symbol.ascii
+        { split.first.char.from.str swap$ }
+        { #2 skip.inter.token.chars.by }
+     if$
+    }
+  if$
+}
+
+FUNCTION {is.special.char.command}
+{
+  #2 global.max$ substring$ skip.inter.token.command
+
+  empty$
+    'skip$
+    { "is.special.char.command: cmdstr has extra components!" warning$ }
+  if$
+
+  duplicate$ duplicate$ duplicate$ duplicate$ duplicate$ duplicate$
+  "oOlLij" swap$ is.char.in.str
+  swap$ "oe" = or
+  swap$ "OE" = or
+  swap$ "ae" = or
+  swap$ "AE" = or
+  swap$ "aa" = or
+  swap$ "AA" = or
+}
+
+FUNCTION {map.char}
+{
+  't :=
+  split.first.char.from.str
+  { swap$ duplicate$ "" = not }
+    {
+      swap$ t =
+        { pop$ "" t }
+        {
+          swap$ split.first.char.from.str pop$ swap$
+          split.first.char.from.str
+        }
+      if$
+    }
+  while$
+  pop$ t =
+    'get.first.char.from.str
+    { pop$ t }
+  if$
+}
+
+FUNCTION {to.lower}
+{
+  duplicate$ is.upper.ascii
+    { chr.to.int$ #32 + int.to.chr$ }
+    { latin.lower swap$ latin.upper swap$ map.char }
+  if$
+}
+
+FUNCTION {to.upper}
+{
+  duplicate$ is.lower.ascii
+    { chr.to.int$ #32 - int.to.chr$ }
+    { latin.upper swap$ latin.lower swap$ map.char }
+  if$
+}
+
+FUNCTION {all.to.lower}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.lower swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.lower}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+          duplicate$ is.special.char.command
+            'all.to.lower
+            'skip$
+          if$
+        }
+        'to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.lower}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+        {
+          split.first.char.from.str
+          duplicate$ #92 int.to.chr$ =
+            {
+              swap$ skip.inter.token.command 't := * t
+              swap$ command.to.lower
+            }
+            'to.lower
+          if$
+          swap$ 't := * t
+        }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {all.to.upper}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.upper swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.upper}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+           duplicate$ is.special.char.command
+             'all.to.upper
+             'skip$
+           if$
+        }
+        'to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.upper}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+      {
+        split.first.char.from.str
+        duplicate$ #92 int.to.chr$ =
+          {
+            swap$ skip.inter.token.command 't := * t
+            swap$ command.to.upper
+          }
+          'to.upper
+        if$
+        swap$ 't := * t
+      }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {lower.token.if.in.title.case}
+{
+  duplicate$ is.tex.str.in.title.case
+    { split.first.tex.char.from.str tex.to.lower swap$ * }
+    'skip$
+  if$
+}
+
+FUNCTION {self.tokens}
+{
+  #0 =
+    'default.self.tokens
+    'range.delimiters
+  if$
+}
+
+FUNCTION {tokenize.by}
+{
+  'b :=
+  's :=
+
+  s "" =
+    { "" "" }
+    {
+      s split.first.char.from.str
+      duplicate$ b self.tokens swap$ is.char.in.str
+        'swap$
+        {
+          duplicate$ #92 int.to.chr$ =
+            { swap$ skip.inter.token.command 's := * s }
+            {
+              pop$ pop$ "" s
+              { duplicate$ "" = not }
+                {
+                  split.first.char.from.str
+                  duplicate$ "\ " b self.tokens * swap$ is.char.in.str
+                    { pop$ pop$ "" }
+                    {
+                      duplicate$ "{" =
+                        { swap$ find.match.brace }
+                        'swap$
+                      if$
+                      's := * s
+                    }
+                  if$
+                }
+              while$
+              pop$ s
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tokenize}
+{
+  #0 tokenize.by
+}
+
+FUNCTION {smart.sentence.case}
+{
+  tokenize 's :=
+
+  { s "" = not }
+    {
+      s skip.inter.token.chars 's := * s
+      tokenize swap$
+      duplicate$ ":" =
+        {
+          swap$ 's := *
+          s skip.inter.token.chars 's := * s
+          tokenize swap$
+          lowercase.word.after.colon
+            {
+              duplicate$ "A" =
+                { pop$ "a" }
+                'lower.token.if.in.title.case
+              if$
+            }
+            'skip$
+          if$
+        }
+        'lower.token.if.in.title.case
+      if$
+      swap$ 's := *
+    }
+  while$
+}
+
+FUNCTION {smart.upper.case}
+{
+  s swap$ t swap$
+
+  "" swap$
+  { duplicate$ "" = not }
+    {
+      tokenize swap$
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        'command.to.upper
+        {
+          "" swap$
+          { duplicate$ "" = not }
+            {
+              split.first.tex.char.from.str tex.to.upper
+              swap$ 't := * t
+            }
+          while$
+          pop$
+        }
+      if$
+      swap$ 't := * t
+      skip.inter.token.chars 't := * t
+    }
+  while$
+  pop$
+
+  swap$ 't :=
+  swap$ 's :=
+}
+
 FUNCTION {field.or.null}
 { duplicate$ empty$
     { pop$ "" }
@@ -594,7 +1217,7 @@ FUNCTION {format.name}
       name.lang lang.en =
         { t #1 "{vv~}{ll}{ f{~}}" format.name$
           uppercase.name
-            { "u" change.case$ }
+            'smart.upper.case
             'skip$
           if$
           t #1 "{, jj}" format.name$ *
@@ -773,7 +1396,7 @@ FUNCTION {output.bibitem}
 
 FUNCTION {change.sentence.case}
 { entry.lang lang.en =
-    { "t" change.case$ }
+    'smart.sentence.case
     'skip$
   if$
 }
@@ -1383,32 +2006,27 @@ FUNCTION {format.urldate}
   if$
 }
 
-FUNCTION {hyphenate}
-{ 't :=
-  ""
-    { t empty$ not }
-    { t #1 #1 substring$ "-" =
-        { wave.dash.in.pages
-            { "～" * }
-            { "-" * }
-          if$
-            { t #1 #1 substring$ "-" = }
-            { t #2 global.max$ substring$ 't := }
-          while$
-        }
-        { t #1 #1 substring$ *
-          t #2 global.max$ substring$ 't :=
-        }
+FUNCTION {normalize.page.range}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    {
+      #1 skip.inter.token.chars.by 't :=
+      empty$
+        { "" }
+        'page.range.delimiter
       if$
+      * t
+      #1 tokenize.by 't :=
+      * t
     }
   while$
+  pop$
 }
 
 FUNCTION {format.pages}
-{ pages empty$
-    { "" }
-    { pages hyphenate }
-  if$
+{
+  pages normalize.page.range
 }
 
 FUNCTION {format.extracted.pages}
@@ -1416,8 +2034,8 @@ FUNCTION {format.extracted.pages}
     { "" }
     { pages
       only.start.page
-        'extract.before.dash
-        'hyphenate
+        { #1 tokenize.by pop$ }
+        'normalize.page.range
       if$
     }
   if$

--- a/gbt7714-author-year.bst
+++ b/gbt7714-author-year.bst
@@ -44,7 +44,6 @@ INTEGERS {
   show.missing.address.publisher
   space.before.pages
   only.start.page
-  wave.dash.in.pages
   show.urldate
   show.url
   show.doi
@@ -52,6 +51,7 @@ INTEGERS {
   show.note
   show.english.translation
   end.with.period
+  lowercase.word.after.colon
   lang.zh.order
   lang.ja.order
   lang.en.order
@@ -61,6 +61,7 @@ INTEGERS {
 
 STRINGS {
   component.part.label
+  page.range.delimiter
 }
 
 FUNCTION {load.config}
@@ -89,7 +90,7 @@ FUNCTION {load.config}
   #0 'show.missing.address.publisher :=
   #1 'space.before.pages :=
   #0 'only.start.page :=
-  #0 'wave.dash.in.pages :=
+  "-" 'page.range.delimiter :=
   #1 'show.urldate :=
   #1 'show.url :=
   #1 'show.doi :=
@@ -97,6 +98,7 @@ FUNCTION {load.config}
   #0 'show.note :=
   #0 'show.english.translation :=
   #1 'end.with.period :=
+  #1 'lowercase.word.after.colon :=
   #1 'lang.zh.order :=
   #2 'lang.ja.order :=
   #3 'lang.en.order :=
@@ -243,6 +245,14 @@ FUNCTION {bbl.sine.loco.sine.nomine}
     { "[S.l.: s.n.]" }
   if$
 }
+
+FUNCTION {default.self.tokens} { ":,-'–—?.!" }
+
+FUNCTION {latin.upper} { "ÀÁÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİIĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ" }
+
+FUNCTION {latin.lower} { "àáãäåæçèéêëìíîïðñòóôõöøùúûüýþÿāăąćĉċčďđēĕėęěĝğġģĥħĩīĭįiıĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" }
+
+FUNCTION {range.delimiters} { "-–—～" }
 
 FUNCTION {not}
 {   { #0 }
@@ -449,6 +459,619 @@ FUNCTION {new.sentence.checkb}
   if$
 }
 
+INTEGERS { b }
+
+FUNCTION {is.int.in.range}
+{
+  'b :=
+  #1 +
+  b >
+    { #1 - b < }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {mult.power2}
+{
+  { duplicate$ #0 > }
+    {
+      swap$
+      duplicate$ +
+      swap$ #1 -
+    }
+  while$
+  pop$
+}
+
+FUNCTION {find.match.brace}
+{
+  's :=
+  't :=
+
+  #1
+  { duplicate$ #0 >
+    s empty$ not and }
+    {
+      s #1 #1 substring$ "{" =
+        { #1 + }
+        {
+          s #1 #1 substring$ "}" =
+            { #1 - }
+            'skip$
+          if$
+        }
+      if$
+      t s #1 #1 substring$ * 't :=
+      s #2 global.max$ substring$ 's :=
+    }
+  while$
+
+  duplicate$ #0 >
+    {
+      "Unbalanced brace(s): one or more closing braces are missing" warning$
+      { duplicate$ #0 > }
+        {
+          t "}" * 't :=
+          #1 -
+        }
+      while$
+    }
+    'skip$
+  if$
+  pop$
+
+  t
+  s
+}
+
+FUNCTION {split.first.char.from.str}
+{
+  duplicate$ "" =
+    {
+      "split.first.char.from.str: Trying to split an empty string!" warning$
+      ""
+    }
+    {
+      duplicate$ #1 #1 substring$ chr.to.int$ #128 <
+        {
+          duplicate$ #1 #1 substring$ swap$
+          #2 global.max$ substring$ swap$
+        }
+        {
+          duplicate$ #1 #1 substring$ chr.to.int$ #224 <
+            {
+              duplicate$ #1 #2 substring$ swap$
+              #3 global.max$ substring$ swap$
+            }
+            {
+              duplicate$ #1 #1 substring$ chr.to.int$ #240 <
+                {
+                  duplicate$ #1 #3 substring$ swap$
+                  #4 global.max$ substring$ swap$
+                }
+                {
+                  duplicate$ #1 #4 substring$ swap$
+                  #5 global.max$ substring$ swap$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {get.first.char.from.str}
+{
+  split.first.char.from.str swap$ pop$
+}
+
+FUNCTION {split.first.tex.char.from.str}
+{
+  duplicate$ #1 #1 substring$ "{" =
+    {
+      split.first.char.from.str swap$
+      find.match.brace swap$
+    }
+    'split.first.char.from.str
+  if$
+}
+
+FUNCTION {char.to.unicode}
+{
+  duplicate$ #4 #1 substring$ "" =
+    {
+      duplicate$ #3 #1 substring$ "" =
+        {
+          duplicate$ #2 #1 substring$ "" =
+            {
+              duplicate$ "" =
+                {
+                  "Empty string is not a char!" warning$
+                  pop$ #-1
+                }
+                { #1 #1 substring$ chr.to.int$ }
+              if$
+            }
+            {
+              duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+              #1 #1 substring$ chr.to.int$ #192 -
+              #6 mult.power2 +
+            }
+          if$
+        }
+        {
+          duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+          duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+          #1 #1 substring$ chr.to.int$ #224 -
+          #6 mult.power2 +
+          #6 mult.power2 +
+        }
+      if$
+    }
+    {
+      duplicate$ #4 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+      #1 #1 substring$ chr.to.int$ #240 -
+      #6 mult.power2 +
+      #6 mult.power2 +
+      #6 mult.power2 +
+    }
+  if$
+}
+
+FUNCTION {is.char.in.str}
+{
+  't :=
+
+  t "" =
+    { "is.char.in.str: Empty string is not a char!" warning$ }
+    'skip$
+  if$
+
+  #0 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str t =
+        { pop$ pop$ #1 "" }
+        'skip$
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.upper.ascii}
+{
+  char.to.unicode #65 swap$ #90 swap$ is.int.in.range
+}
+
+FUNCTION {is.upper}
+{
+  duplicate$ is.upper.ascii
+    { pop$ #1 }
+    { latin.upper swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.lower.ascii}
+{
+  char.to.unicode #97 swap$ #122 swap$ is.int.in.range
+}
+
+FUNCTION {is.lower}
+{
+  duplicate$ is.lower.ascii
+    { pop$ #1 }
+    { latin.lower swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.printable.ascii}
+{
+  char.to.unicode #32 swap$ #126 swap$ is.int.in.range
+}
+
+FUNCTION {is.letter.ascii}
+{
+  duplicate$ is.upper.ascii swap$ is.lower.ascii or
+}
+
+FUNCTION {is.symbol.ascii}
+{
+  duplicate$ is.printable.ascii swap$ is.letter.ascii not and
+}
+
+FUNCTION {is.all.lower}
+{
+  #1 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str is.lower
+        'skip$
+        { pop$ pop$ #0 "" }
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.tex.str.in.title.case}
+{
+  duplicate$ "" =
+    { pop$ #0 }
+    {
+      split.first.tex.char.from.str purify$
+      duplicate$ "" =
+        { pop$ pop$ #0 }
+        {
+          split.first.char.from.str is.upper
+            {
+              duplicate$ is.all.lower
+                {
+                  empty$
+                    {
+                      duplicate$ "" =
+                        { pop$ #0 }
+                        'is.all.lower
+                      if$
+                    }
+                    'is.all.lower
+                  if$
+                }
+                { pop$ pop$ #0 }
+              if$
+            }
+            { pop$ pop$ #0}
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {is.in.inter.token.chars}
+{
+  duplicate$ #0 =
+    { pop$ " " = }
+    {
+      #1 =
+        { " " range.delimiters * swap$ is.char.in.str }
+        'is.letter.ascii
+      if$
+    }
+  if$
+}
+
+FUNCTION {skip.inter.token.chars.by}
+{
+  'b :=
+  't :=
+
+  "" t
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str
+      duplicate$ b is.in.inter.token.chars
+        { swap$ 't := * t }
+        { swap$ * 't := "" }
+      if$
+    }
+  while$
+
+  pop$ t
+}
+
+FUNCTION {skip.inter.token.chars}
+{
+  #0 skip.inter.token.chars.by
+}
+
+FUNCTION {skip.inter.token.command}
+{
+  duplicate$ "" =
+    { "" }
+    {
+      duplicate$ #1 #1 substring$ is.symbol.ascii
+        { split.first.char.from.str swap$ }
+        { #2 skip.inter.token.chars.by }
+     if$
+    }
+  if$
+}
+
+FUNCTION {is.special.char.command}
+{
+  #2 global.max$ substring$ skip.inter.token.command
+
+  empty$
+    'skip$
+    { "is.special.char.command: cmdstr has extra components!" warning$ }
+  if$
+
+  duplicate$ duplicate$ duplicate$ duplicate$ duplicate$ duplicate$
+  "oOlLij" swap$ is.char.in.str
+  swap$ "oe" = or
+  swap$ "OE" = or
+  swap$ "ae" = or
+  swap$ "AE" = or
+  swap$ "aa" = or
+  swap$ "AA" = or
+}
+
+FUNCTION {map.char}
+{
+  't :=
+  split.first.char.from.str
+  { swap$ duplicate$ "" = not }
+    {
+      swap$ t =
+        { pop$ "" t }
+        {
+          swap$ split.first.char.from.str pop$ swap$
+          split.first.char.from.str
+        }
+      if$
+    }
+  while$
+  pop$ t =
+    'get.first.char.from.str
+    { pop$ t }
+  if$
+}
+
+FUNCTION {to.lower}
+{
+  duplicate$ is.upper.ascii
+    { chr.to.int$ #32 + int.to.chr$ }
+    { latin.lower swap$ latin.upper swap$ map.char }
+  if$
+}
+
+FUNCTION {to.upper}
+{
+  duplicate$ is.lower.ascii
+    { chr.to.int$ #32 - int.to.chr$ }
+    { latin.upper swap$ latin.lower swap$ map.char }
+  if$
+}
+
+FUNCTION {all.to.lower}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.lower swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.lower}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+          duplicate$ is.special.char.command
+            'all.to.lower
+            'skip$
+          if$
+        }
+        'to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.lower}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+        {
+          split.first.char.from.str
+          duplicate$ #92 int.to.chr$ =
+            {
+              swap$ skip.inter.token.command 't := * t
+              swap$ command.to.lower
+            }
+            'to.lower
+          if$
+          swap$ 't := * t
+        }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {all.to.upper}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.upper swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.upper}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+           duplicate$ is.special.char.command
+             'all.to.upper
+             'skip$
+           if$
+        }
+        'to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.upper}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+      {
+        split.first.char.from.str
+        duplicate$ #92 int.to.chr$ =
+          {
+            swap$ skip.inter.token.command 't := * t
+            swap$ command.to.upper
+          }
+          'to.upper
+        if$
+        swap$ 't := * t
+      }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {lower.token.if.in.title.case}
+{
+  duplicate$ is.tex.str.in.title.case
+    { split.first.tex.char.from.str tex.to.lower swap$ * }
+    'skip$
+  if$
+}
+
+FUNCTION {self.tokens}
+{
+  #0 =
+    'default.self.tokens
+    'range.delimiters
+  if$
+}
+
+FUNCTION {tokenize.by}
+{
+  'b :=
+  's :=
+
+  s "" =
+    { "" "" }
+    {
+      s split.first.char.from.str
+      duplicate$ b self.tokens swap$ is.char.in.str
+        'swap$
+        {
+          duplicate$ #92 int.to.chr$ =
+            { swap$ skip.inter.token.command 's := * s }
+            {
+              pop$ pop$ "" s
+              { duplicate$ "" = not }
+                {
+                  split.first.char.from.str
+                  duplicate$ "\ " b self.tokens * swap$ is.char.in.str
+                    { pop$ pop$ "" }
+                    {
+                      duplicate$ "{" =
+                        { swap$ find.match.brace }
+                        'swap$
+                      if$
+                      's := * s
+                    }
+                  if$
+                }
+              while$
+              pop$ s
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tokenize}
+{
+  #0 tokenize.by
+}
+
+FUNCTION {smart.sentence.case}
+{
+  tokenize 's :=
+
+  { s "" = not }
+    {
+      s skip.inter.token.chars 's := * s
+      tokenize swap$
+      duplicate$ ":" =
+        {
+          swap$ 's := *
+          s skip.inter.token.chars 's := * s
+          tokenize swap$
+          lowercase.word.after.colon
+            {
+              duplicate$ "A" =
+                { pop$ "a" }
+                'lower.token.if.in.title.case
+              if$
+            }
+            'skip$
+          if$
+        }
+        'lower.token.if.in.title.case
+      if$
+      swap$ 's := *
+    }
+  while$
+}
+
+FUNCTION {smart.upper.case}
+{
+  s swap$ t swap$
+
+  "" swap$
+  { duplicate$ "" = not }
+    {
+      tokenize swap$
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        'command.to.upper
+        {
+          "" swap$
+          { duplicate$ "" = not }
+            {
+              split.first.tex.char.from.str tex.to.upper
+              swap$ 't := * t
+            }
+          while$
+          pop$
+        }
+      if$
+      swap$ 't := * t
+      skip.inter.token.chars 't := * t
+    }
+  while$
+  pop$
+
+  swap$ 't :=
+  swap$ 's :=
+}
+
 FUNCTION {field.or.null}
 { duplicate$ empty$
     { pop$ "" }
@@ -604,7 +1227,7 @@ FUNCTION {format.name}
       name.lang lang.en =
         { t #1 "{vv~}{ll}{ f{~}}" format.name$
           uppercase.name
-            { "u" change.case$ }
+            'smart.upper.case
             'skip$
           if$
           t #1 "{, jj}" format.name$ *
@@ -783,7 +1406,7 @@ FUNCTION {output.bibitem}
 
 FUNCTION {change.sentence.case}
 { entry.lang lang.en =
-    { "t" change.case$ }
+    'smart.sentence.case
     'skip$
   if$
 }
@@ -1393,32 +2016,27 @@ FUNCTION {format.urldate}
   if$
 }
 
-FUNCTION {hyphenate}
-{ 't :=
-  ""
-    { t empty$ not }
-    { t #1 #1 substring$ "-" =
-        { wave.dash.in.pages
-            { "～" * }
-            { "-" * }
-          if$
-            { t #1 #1 substring$ "-" = }
-            { t #2 global.max$ substring$ 't := }
-          while$
-        }
-        { t #1 #1 substring$ *
-          t #2 global.max$ substring$ 't :=
-        }
+FUNCTION {normalize.page.range}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    {
+      #1 skip.inter.token.chars.by 't :=
+      empty$
+        { "" }
+        'page.range.delimiter
       if$
+      * t
+      #1 tokenize.by 't :=
+      * t
     }
   while$
+  pop$
 }
 
 FUNCTION {format.pages}
-{ pages empty$
-    { "" }
-    { pages hyphenate }
-  if$
+{
+  pages normalize.page.range
 }
 
 FUNCTION {format.extracted.pages}
@@ -1426,8 +2044,8 @@ FUNCTION {format.extracted.pages}
     { "" }
     { pages
       only.start.page
-        'extract.before.dash
-        'hyphenate
+        { #1 tokenize.by pop$ }
+        'normalize.page.range
       if$
     }
   if$

--- a/gbt7714-numerical.bst
+++ b/gbt7714-numerical.bst
@@ -44,7 +44,6 @@ INTEGERS {
   show.missing.address.publisher
   space.before.pages
   only.start.page
-  wave.dash.in.pages
   show.urldate
   show.url
   show.doi
@@ -52,10 +51,12 @@ INTEGERS {
   show.note
   show.english.translation
   end.with.period
+  lowercase.word.after.colon
 }
 
 STRINGS {
   component.part.label
+  page.range.delimiter
 }
 
 FUNCTION {load.config}
@@ -84,7 +85,7 @@ FUNCTION {load.config}
   #0 'show.missing.address.publisher :=
   #1 'space.before.pages :=
   #0 'only.start.page :=
-  #0 'wave.dash.in.pages :=
+  "-" 'page.range.delimiter :=
   #1 'show.urldate :=
   #1 'show.url :=
   #1 'show.doi :=
@@ -92,6 +93,7 @@ FUNCTION {load.config}
   #0 'show.note :=
   #0 'show.english.translation :=
   #1 'end.with.period :=
+  #1 'lowercase.word.after.colon :=
 }
 
 ENTRY
@@ -233,6 +235,14 @@ FUNCTION {bbl.sine.loco.sine.nomine}
     { "[S.l.: s.n.]" }
   if$
 }
+
+FUNCTION {default.self.tokens} { ":,-'–—?.!" }
+
+FUNCTION {latin.upper} { "ÀÁÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİIĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ" }
+
+FUNCTION {latin.lower} { "àáãäåæçèéêëìíîïðñòóôõöøùúûüýþÿāăąćĉċčďđēĕėęěĝğġģĥħĩīĭįiıĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" }
+
+FUNCTION {range.delimiters} { "-–—～" }
 
 FUNCTION {not}
 {   { #0 }
@@ -439,6 +449,619 @@ FUNCTION {new.sentence.checkb}
   if$
 }
 
+INTEGERS { b }
+
+FUNCTION {is.int.in.range}
+{
+  'b :=
+  #1 +
+  b >
+    { #1 - b < }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {mult.power2}
+{
+  { duplicate$ #0 > }
+    {
+      swap$
+      duplicate$ +
+      swap$ #1 -
+    }
+  while$
+  pop$
+}
+
+FUNCTION {find.match.brace}
+{
+  's :=
+  't :=
+
+  #1
+  { duplicate$ #0 >
+    s empty$ not and }
+    {
+      s #1 #1 substring$ "{" =
+        { #1 + }
+        {
+          s #1 #1 substring$ "}" =
+            { #1 - }
+            'skip$
+          if$
+        }
+      if$
+      t s #1 #1 substring$ * 't :=
+      s #2 global.max$ substring$ 's :=
+    }
+  while$
+
+  duplicate$ #0 >
+    {
+      "Unbalanced brace(s): one or more closing braces are missing" warning$
+      { duplicate$ #0 > }
+        {
+          t "}" * 't :=
+          #1 -
+        }
+      while$
+    }
+    'skip$
+  if$
+  pop$
+
+  t
+  s
+}
+
+FUNCTION {split.first.char.from.str}
+{
+  duplicate$ "" =
+    {
+      "split.first.char.from.str: Trying to split an empty string!" warning$
+      ""
+    }
+    {
+      duplicate$ #1 #1 substring$ chr.to.int$ #128 <
+        {
+          duplicate$ #1 #1 substring$ swap$
+          #2 global.max$ substring$ swap$
+        }
+        {
+          duplicate$ #1 #1 substring$ chr.to.int$ #224 <
+            {
+              duplicate$ #1 #2 substring$ swap$
+              #3 global.max$ substring$ swap$
+            }
+            {
+              duplicate$ #1 #1 substring$ chr.to.int$ #240 <
+                {
+                  duplicate$ #1 #3 substring$ swap$
+                  #4 global.max$ substring$ swap$
+                }
+                {
+                  duplicate$ #1 #4 substring$ swap$
+                  #5 global.max$ substring$ swap$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {get.first.char.from.str}
+{
+  split.first.char.from.str swap$ pop$
+}
+
+FUNCTION {split.first.tex.char.from.str}
+{
+  duplicate$ #1 #1 substring$ "{" =
+    {
+      split.first.char.from.str swap$
+      find.match.brace swap$
+    }
+    'split.first.char.from.str
+  if$
+}
+
+FUNCTION {char.to.unicode}
+{
+  duplicate$ #4 #1 substring$ "" =
+    {
+      duplicate$ #3 #1 substring$ "" =
+        {
+          duplicate$ #2 #1 substring$ "" =
+            {
+              duplicate$ "" =
+                {
+                  "Empty string is not a char!" warning$
+                  pop$ #-1
+                }
+                { #1 #1 substring$ chr.to.int$ }
+              if$
+            }
+            {
+              duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+              #1 #1 substring$ chr.to.int$ #192 -
+              #6 mult.power2 +
+            }
+          if$
+        }
+        {
+          duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+          duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+          #1 #1 substring$ chr.to.int$ #224 -
+          #6 mult.power2 +
+          #6 mult.power2 +
+        }
+      if$
+    }
+    {
+      duplicate$ #4 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+      #1 #1 substring$ chr.to.int$ #240 -
+      #6 mult.power2 +
+      #6 mult.power2 +
+      #6 mult.power2 +
+    }
+  if$
+}
+
+FUNCTION {is.char.in.str}
+{
+  't :=
+
+  t "" =
+    { "is.char.in.str: Empty string is not a char!" warning$ }
+    'skip$
+  if$
+
+  #0 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str t =
+        { pop$ pop$ #1 "" }
+        'skip$
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.upper.ascii}
+{
+  char.to.unicode #65 swap$ #90 swap$ is.int.in.range
+}
+
+FUNCTION {is.upper}
+{
+  duplicate$ is.upper.ascii
+    { pop$ #1 }
+    { latin.upper swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.lower.ascii}
+{
+  char.to.unicode #97 swap$ #122 swap$ is.int.in.range
+}
+
+FUNCTION {is.lower}
+{
+  duplicate$ is.lower.ascii
+    { pop$ #1 }
+    { latin.lower swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.printable.ascii}
+{
+  char.to.unicode #32 swap$ #126 swap$ is.int.in.range
+}
+
+FUNCTION {is.letter.ascii}
+{
+  duplicate$ is.upper.ascii swap$ is.lower.ascii or
+}
+
+FUNCTION {is.symbol.ascii}
+{
+  duplicate$ is.printable.ascii swap$ is.letter.ascii not and
+}
+
+FUNCTION {is.all.lower}
+{
+  #1 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str is.lower
+        'skip$
+        { pop$ pop$ #0 "" }
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.tex.str.in.title.case}
+{
+  duplicate$ "" =
+    { pop$ #0 }
+    {
+      split.first.tex.char.from.str purify$
+      duplicate$ "" =
+        { pop$ pop$ #0 }
+        {
+          split.first.char.from.str is.upper
+            {
+              duplicate$ is.all.lower
+                {
+                  empty$
+                    {
+                      duplicate$ "" =
+                        { pop$ #0 }
+                        'is.all.lower
+                      if$
+                    }
+                    'is.all.lower
+                  if$
+                }
+                { pop$ pop$ #0 }
+              if$
+            }
+            { pop$ pop$ #0}
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {is.in.inter.token.chars}
+{
+  duplicate$ #0 =
+    { pop$ " " = }
+    {
+      #1 =
+        { " " range.delimiters * swap$ is.char.in.str }
+        'is.letter.ascii
+      if$
+    }
+  if$
+}
+
+FUNCTION {skip.inter.token.chars.by}
+{
+  'b :=
+  't :=
+
+  "" t
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str
+      duplicate$ b is.in.inter.token.chars
+        { swap$ 't := * t }
+        { swap$ * 't := "" }
+      if$
+    }
+  while$
+
+  pop$ t
+}
+
+FUNCTION {skip.inter.token.chars}
+{
+  #0 skip.inter.token.chars.by
+}
+
+FUNCTION {skip.inter.token.command}
+{
+  duplicate$ "" =
+    { "" }
+    {
+      duplicate$ #1 #1 substring$ is.symbol.ascii
+        { split.first.char.from.str swap$ }
+        { #2 skip.inter.token.chars.by }
+     if$
+    }
+  if$
+}
+
+FUNCTION {is.special.char.command}
+{
+  #2 global.max$ substring$ skip.inter.token.command
+
+  empty$
+    'skip$
+    { "is.special.char.command: cmdstr has extra components!" warning$ }
+  if$
+
+  duplicate$ duplicate$ duplicate$ duplicate$ duplicate$ duplicate$
+  "oOlLij" swap$ is.char.in.str
+  swap$ "oe" = or
+  swap$ "OE" = or
+  swap$ "ae" = or
+  swap$ "AE" = or
+  swap$ "aa" = or
+  swap$ "AA" = or
+}
+
+FUNCTION {map.char}
+{
+  't :=
+  split.first.char.from.str
+  { swap$ duplicate$ "" = not }
+    {
+      swap$ t =
+        { pop$ "" t }
+        {
+          swap$ split.first.char.from.str pop$ swap$
+          split.first.char.from.str
+        }
+      if$
+    }
+  while$
+  pop$ t =
+    'get.first.char.from.str
+    { pop$ t }
+  if$
+}
+
+FUNCTION {to.lower}
+{
+  duplicate$ is.upper.ascii
+    { chr.to.int$ #32 + int.to.chr$ }
+    { latin.lower swap$ latin.upper swap$ map.char }
+  if$
+}
+
+FUNCTION {to.upper}
+{
+  duplicate$ is.lower.ascii
+    { chr.to.int$ #32 - int.to.chr$ }
+    { latin.upper swap$ latin.lower swap$ map.char }
+  if$
+}
+
+FUNCTION {all.to.lower}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.lower swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.lower}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+          duplicate$ is.special.char.command
+            'all.to.lower
+            'skip$
+          if$
+        }
+        'to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.lower}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+        {
+          split.first.char.from.str
+          duplicate$ #92 int.to.chr$ =
+            {
+              swap$ skip.inter.token.command 't := * t
+              swap$ command.to.lower
+            }
+            'to.lower
+          if$
+          swap$ 't := * t
+        }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {all.to.upper}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.upper swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.upper}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+           duplicate$ is.special.char.command
+             'all.to.upper
+             'skip$
+           if$
+        }
+        'to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.upper}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+      {
+        split.first.char.from.str
+        duplicate$ #92 int.to.chr$ =
+          {
+            swap$ skip.inter.token.command 't := * t
+            swap$ command.to.upper
+          }
+          'to.upper
+        if$
+        swap$ 't := * t
+      }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {lower.token.if.in.title.case}
+{
+  duplicate$ is.tex.str.in.title.case
+    { split.first.tex.char.from.str tex.to.lower swap$ * }
+    'skip$
+  if$
+}
+
+FUNCTION {self.tokens}
+{
+  #0 =
+    'default.self.tokens
+    'range.delimiters
+  if$
+}
+
+FUNCTION {tokenize.by}
+{
+  'b :=
+  's :=
+
+  s "" =
+    { "" "" }
+    {
+      s split.first.char.from.str
+      duplicate$ b self.tokens swap$ is.char.in.str
+        'swap$
+        {
+          duplicate$ #92 int.to.chr$ =
+            { swap$ skip.inter.token.command 's := * s }
+            {
+              pop$ pop$ "" s
+              { duplicate$ "" = not }
+                {
+                  split.first.char.from.str
+                  duplicate$ "\ " b self.tokens * swap$ is.char.in.str
+                    { pop$ pop$ "" }
+                    {
+                      duplicate$ "{" =
+                        { swap$ find.match.brace }
+                        'swap$
+                      if$
+                      's := * s
+                    }
+                  if$
+                }
+              while$
+              pop$ s
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tokenize}
+{
+  #0 tokenize.by
+}
+
+FUNCTION {smart.sentence.case}
+{
+  tokenize 's :=
+
+  { s "" = not }
+    {
+      s skip.inter.token.chars 's := * s
+      tokenize swap$
+      duplicate$ ":" =
+        {
+          swap$ 's := *
+          s skip.inter.token.chars 's := * s
+          tokenize swap$
+          lowercase.word.after.colon
+            {
+              duplicate$ "A" =
+                { pop$ "a" }
+                'lower.token.if.in.title.case
+              if$
+            }
+            'skip$
+          if$
+        }
+        'lower.token.if.in.title.case
+      if$
+      swap$ 's := *
+    }
+  while$
+}
+
+FUNCTION {smart.upper.case}
+{
+  s swap$ t swap$
+
+  "" swap$
+  { duplicate$ "" = not }
+    {
+      tokenize swap$
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        'command.to.upper
+        {
+          "" swap$
+          { duplicate$ "" = not }
+            {
+              split.first.tex.char.from.str tex.to.upper
+              swap$ 't := * t
+            }
+          while$
+          pop$
+        }
+      if$
+      swap$ 't := * t
+      skip.inter.token.chars 't := * t
+    }
+  while$
+  pop$
+
+  swap$ 't :=
+  swap$ 's :=
+}
+
 FUNCTION {field.or.null}
 { duplicate$ empty$
     { pop$ "" }
@@ -594,7 +1217,7 @@ FUNCTION {format.name}
       name.lang lang.en =
         { t #1 "{vv~}{ll}{ f{~}}" format.name$
           uppercase.name
-            { "u" change.case$ }
+            'smart.upper.case
             'skip$
           if$
           t #1 "{, jj}" format.name$ *
@@ -773,7 +1396,7 @@ FUNCTION {output.bibitem}
 
 FUNCTION {change.sentence.case}
 { entry.lang lang.en =
-    { "t" change.case$ }
+    'smart.sentence.case
     'skip$
   if$
 }
@@ -1383,32 +2006,27 @@ FUNCTION {format.urldate}
   if$
 }
 
-FUNCTION {hyphenate}
-{ 't :=
-  ""
-    { t empty$ not }
-    { t #1 #1 substring$ "-" =
-        { wave.dash.in.pages
-            { "～" * }
-            { "-" * }
-          if$
-            { t #1 #1 substring$ "-" = }
-            { t #2 global.max$ substring$ 't := }
-          while$
-        }
-        { t #1 #1 substring$ *
-          t #2 global.max$ substring$ 't :=
-        }
+FUNCTION {normalize.page.range}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    {
+      #1 skip.inter.token.chars.by 't :=
+      empty$
+        { "" }
+        'page.range.delimiter
       if$
+      * t
+      #1 tokenize.by 't :=
+      * t
     }
   while$
+  pop$
 }
 
 FUNCTION {format.pages}
-{ pages empty$
-    { "" }
-    { pages hyphenate }
-  if$
+{
+  pages normalize.page.range
 }
 
 FUNCTION {format.extracted.pages}
@@ -1416,8 +2034,8 @@ FUNCTION {format.extracted.pages}
     { "" }
     { pages
       only.start.page
-        'extract.before.dash
-        'hyphenate
+        { #1 tokenize.by pop$ }
+        'normalize.page.range
       if$
     }
   if$

--- a/gbt7714.dtx
+++ b/gbt7714.dtx
@@ -31,11 +31,29 @@
 \usepackage{listings}
 \makeatletter
 \hypersetup{allcolors=blue}
-\IfFileExists{/System/Library/Fonts/Palatino.ttc}{
-  \setmainfont{Palatino}
-  \setsansfont[Scale=MatchLowercase]{Helvetica}
-  \setmonofont[Scale=MatchLowercase]{Menlo}
-}{}
+\setmainfont{texgyretermes}[
+  Extension      = .otf,
+  UprightFont    = *-regular,
+  BoldFont       = *-bold,
+  ItalicFont     = *-italic,
+  BoldItalicFont = *-bolditalic,
+]%
+\setsansfont{texgyreheros}[
+  Extension      = .otf,
+  UprightFont    = *-regular,
+  BoldFont       = *-bold,
+  ItalicFont     = *-italic,
+  BoldItalicFont = *-bolditalic,
+]%
+\setmonofont{texgyrecursor}[
+  Extension      = .otf,
+  UprightFont    = *-regular,
+  BoldFont       = *-bold,
+  ItalicFont     = *-italic,
+  BoldItalicFont = *-bolditalic,
+  Scale          = MatchLowercase,
+  Ligatures      = CommonOff,
+]%
 \citestyle{super}
 \lstnewenvironment{latex}{%
   \lstset{
@@ -345,13 +363,14 @@
 %   show.missing.address.publisher & |#0|   & 出版项缺失时显示“出版者不详”   \\
 %   space.before.pages             & |#1|   & 页码与前面的冒号之间有空格     \\
 %   only.start.page                & |#0|   & 只显示起始页码                 \\
-%   wave.dash.in.pages             & |#0|   & 起止页码使用波浪号             \\
+%   page.range.delimiter           & |"-"|  & 起止页码中的连接号             \\
 %   show.urldate                   & |#1|   & 显示引用日期 urldate           \\
 %   show.url                       & |#1|   & 显示 url                       \\
 %   show.doi                       & |#1|   & 显示 DOI                       \\
 %   show.preprint                  & |#1|   & 显示预印本信息                 \\
 %   show.note                      & |#0|   & 显示 note 域的信息             \\
 %   end.with.period                & |#1|   & 结尾加句点                     \\
+%   lowercase.word.after.colon     & |#1|   & 将冒号后的单词变成小写 \\
 %   \bottomrule
 % \end{tabular}
 % \end{table}
@@ -949,7 +968,6 @@ INTEGERS {
   show.missing.address.publisher
   space.before.pages
   only.start.page
-  wave.dash.in.pages
   show.urldate
   show.url
   show.doi
@@ -957,6 +975,7 @@ INTEGERS {
   show.note
   show.english.translation
   end.with.period
+  lowercase.word.after.colon
 %<*author-year>
   lang.zh.order
   lang.ja.order
@@ -968,6 +987,7 @@ INTEGERS {
 
 STRINGS {
   component.part.label
+  page.range.delimiter
 }
 
 %    \end{macrocode}
@@ -1197,14 +1217,17 @@ FUNCTION {load.config}
 %</only-start-page>
 %    \end{macrocode}
 %
-% 起止页码使用波浪号：
+% 起止页码中的连接号：
 %    \begin{macrocode}
-%<*!wave-dash-in-pages>
-  #0 'wave.dash.in.pages :=
-%</!wave-dash-in-pages>
-%<*wave-dash-in-pages>
-  #1 'wave.dash.in.pages :=
-%</wave-dash-in-pages>
+%<*!(en-dash-page-range-delimiter|wave-dash-page-range-delimiter)>
+  "-" 'page.range.delimiter :=
+%</!(en-dash-page-range-delimiter|wave-dash-page-range-delimiter)>
+%<*en-dash-page-range-delimiter>
+  "--" 'page.range.delimiter :=
+%</en-dash-page-range-delimiter>
+%<*wave-dash-page-range-delimiter>
+  "～" 'page.range.delimiter :=
+%</wave-dash-page-range-delimiter>
 %    \end{macrocode}
 %
 % 是否著录非电子文献的引用日期：
@@ -1270,6 +1293,16 @@ FUNCTION {load.config}
 %<*no-period-at-end>
   #0 'end.with.period :=
 %</no-period-at-end>
+%    \end{macrocode}
+%
+% 将冒号后的单词变成小写
+%    \begin{macrocode}
+%<*!no-lowercase-word-after-colon>
+  #1 'lowercase.word.after.colon :=
+%</!no-lowercase-word-after-colon>
+%<*no-lowercase-word-after-colon>
+  #0 'lowercase.word.after.colon :=
+%</no-lowercase-word-after-colon>
 %    \end{macrocode}
 %
 % 参考文献表按照“著者-出版年”组织时，各个文种的顺序：
@@ -1608,6 +1641,14 @@ FUNCTION {bbl.sine.loco.sine.nomine}
   if$
 }
 
+FUNCTION {default.self.tokens} { ":,-'–—?.!" }
+
+FUNCTION {latin.upper} { "ÀÁÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİIĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ" }
+
+FUNCTION {latin.lower} { "àáãäåæçèéêëìíîïðñòóôõöøùúûüýþÿāăąćĉċčďđēĕėęěĝğġģĥħĩīĭįiıĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" }
+
+FUNCTION {range.delimiters} { "-–—～" }
+
 %    \end{macrocode}
 %
 % These three functions pop one or two (integer) arguments from the stack
@@ -1837,6 +1878,785 @@ FUNCTION {new.sentence.checkb}
     'skip$
     'new.sentence
   if$
+}
+
+%    \end{macrocode}
+%
+% In order to support UTF-8 encoding, we need some auxiliary functions.  Below
+% are a series of such functions.  We try to make functions loosely-coupled as
+% much as possible.  Where the use of variables is inevitable in functions, we
+% generally assume it is the caller's responsibility to save and restore those
+% variables.  Exceptions are made for some unary functions, where it is
+% convenient for the callee to do so.
+%    \begin{macrocode}
+INTEGERS { b }
+
+%    \end{macrocode}
+%
+% Function |is.int.in.range| takes a codepoint and two integers and check if the
+% codepoint is between these two integers (inclusive).
+%    \begin{macrocode}
+% codepoint: int, a: int, b: int -> bool
+% variable used: b
+FUNCTION {is.int.in.range}
+{
+  'b :=
+  #1 +
+  b >
+    { #1 - b < }
+    { pop$ #0 }
+  if$
+}
+
+%    \end{macrocode}
+%
+% Function |mult.power2| takes two integers and returns \(2^nm\).
+%    \begin{macrocode}
+% m: int, n: int -> int
+FUNCTION {mult.power2}
+{
+  { duplicate$ #0 > }
+    {
+      swap$
+      duplicate$ +
+      swap$ #1 -
+    }
+  while$
+  pop$
+}
+
+%    \end{macrocode}
+%
+% Function |find.match.brace| takes two strings, the first of which is assumed
+% to be |"{"|, and find the matching brace in the second string.  It returns a
+% token (or subtoken) and the rest of the string after the matching brace.  When
+% braces are unmatched, it issues a warning and complete the brace
+% automatically, following the convention of the original \hologo{BibTeX}.
+%    \begin{macrocode}
+% "{", str -> subtoken: str, rest: str
+% variables used: s, t
+FUNCTION {find.match.brace}
+{
+  's :=
+  't :=
+
+  #1
+  { duplicate$ #0 >
+    s empty$ not and }
+    {
+      s #1 #1 substring$ "{" =
+        { #1 + }
+        {
+          s #1 #1 substring$ "}" =
+            { #1 - }
+            'skip$
+          if$
+        }
+      if$
+      t s #1 #1 substring$ * 't :=
+      s #2 global.max$ substring$ 's :=
+    }
+  while$
+
+  duplicate$ #0 >
+    {
+      "Unbalanced brace(s): one or more closing braces are missing" warning$
+      { duplicate$ #0 > }
+        {
+          t "}" * 't :=
+          #1 -
+        }
+      while$
+    }
+    'skip$
+  if$
+  pop$
+
+  t
+  s
+}
+
+%    \end{macrocode}
+%
+% Function |split.first.char.from.str| takes a UTF-8 string and return
+% the first UTF-8 character and the rest of the string in reverse order.
+%    \begin{macrocode}
+% str -> str, char
+FUNCTION {split.first.char.from.str}
+{
+  duplicate$ "" =
+    {
+      "split.first.char.from.str: Trying to split an empty string!" warning$
+      ""
+    }
+    {
+      duplicate$ #1 #1 substring$ chr.to.int$ #128 <
+        {
+          duplicate$ #1 #1 substring$ swap$
+          #2 global.max$ substring$ swap$
+        }
+        {
+          duplicate$ #1 #1 substring$ chr.to.int$ #224 <
+            {
+              duplicate$ #1 #2 substring$ swap$
+              #3 global.max$ substring$ swap$
+            }
+            {
+              duplicate$ #1 #1 substring$ chr.to.int$ #240 <
+                {
+                  duplicate$ #1 #3 substring$ swap$
+                  #4 global.max$ substring$ swap$
+                }
+                {
+                  duplicate$ #1 #4 substring$ swap$
+                  #5 global.max$ substring$ swap$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+%    \end{macrocode}
+%
+% Function |get.first.char.from.str| takes a UTF-8 string and return the
+% first UTF-8 character.
+%    \begin{macrocode}
+% str -> char
+FUNCTION {get.first.char.from.str}
+{
+  split.first.char.from.str swap$ pop$
+}
+
+%    \end{macrocode}
+%
+% Function |split.first.tex.char.from.str| is like
+% |split.first.char.from.str|.  It takes a UTF-8 string and return the
+% first UTF-8 character or first \TeX group and the rest of string in
+% reverse order.
+%    \begin{macrocode}
+% str -> rest: str, texchar
+FUNCTION {split.first.tex.char.from.str}
+{
+  duplicate$ #1 #1 substring$ "{" =
+    {
+      split.first.char.from.str swap$
+      find.match.brace swap$
+    }
+    'split.first.char.from.str
+  if$
+}
+
+%    \end{macrocode}
+%
+% Function |char.to.unicode| takes a UTF-8 character and returns its
+% codepoint in Unicode.  It issues a warning and returns \(-1\) if the
+% presumed character is an empty string.  For other invalid input, the
+% behavior is undefined.
+%    \begin{macrocode}
+% char -> int
+FUNCTION {char.to.unicode}
+{
+  duplicate$ #4 #1 substring$ "" =
+    {
+      duplicate$ #3 #1 substring$ "" =
+        {
+          duplicate$ #2 #1 substring$ "" =
+            {
+              duplicate$ "" =
+                {
+                  "Empty string is not a char!" warning$
+                  pop$ #-1
+                }
+                { #1 #1 substring$ chr.to.int$ }
+              if$
+            }
+            {
+              duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+              #1 #1 substring$ chr.to.int$ #192 -
+              #6 mult.power2 +
+            }
+          if$
+        }
+        {
+          duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+          duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+          #1 #1 substring$ chr.to.int$ #224 -
+          #6 mult.power2 +
+          #6 mult.power2 +
+        }
+      if$
+    }
+    {
+      duplicate$ #4 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+      #1 #1 substring$ chr.to.int$ #240 -
+      #6 mult.power2 +
+      #6 mult.power2 +
+      #6 mult.power2 +
+    }
+  if$
+}
+
+%    \end{macrocode}
+%
+% Function |is.char.in.str| takes a string and a UTF-8 character.  It
+% checks whether the character is in the string.  It issues a warning
+% and returns \(0\) if the presumed character is an empty string.  It
+% also returns \(0\) if the string itself is empty.  For other input,
+% the behavior is undefined.
+%    \begin{macrocode}
+% str, char -> bool
+% variable used: t
+FUNCTION {is.char.in.str}
+{
+  't :=
+
+  t "" =
+    { "is.char.in.str: Empty string is not a char!" warning$ }
+    'skip$
+  if$
+
+  #0 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str t =
+        { pop$ pop$ #1 "" }
+        'skip$
+      if$
+    }
+  while$
+  pop$
+}
+
+%    \end{macrocode}
+%
+% Function |is.upper.ascii| takes a UTF-8 character and checks whether
+% it is an uppercase ASCII letter.
+%    \begin{macrocode}
+% char -> bool
+% variable used: b
+FUNCTION {is.upper.ascii}
+{
+  char.to.unicode #65 swap$ #90 swap$ is.int.in.range
+}
+
+%    \end{macrocode}
+%
+% Function |is.upper| takes a UTF-8 character and checks whether it is
+% uppercase in the range from |U+0000| to |U+017F|.
+%    \begin{macrocode}
+% char -> bool
+% variable used: b
+FUNCTION {is.upper}
+{
+  duplicate$ is.upper.ascii
+    { pop$ #1 }
+    { latin.upper swap$ is.char.in.str }
+  if$
+}
+
+%    \end{macrocode}
+%
+% Function |is.lower.ascii| takes a UTF-8 character and checks whether
+% it is a lowercase ASCII letter.
+%    \begin{macrocode}
+% char -> bool
+% variable used: b
+FUNCTION {is.lower.ascii}
+{
+  char.to.unicode #97 swap$ #122 swap$ is.int.in.range
+}
+
+%    \end{macrocode}
+%
+% Function |is.upper| takes a UTF-8 character and checks whether it is
+% lowercase in the range from |U+0000| to |U+017F|.
+%    \begin{macrocode}
+% char -> bool
+% variable used: b
+FUNCTION {is.lower}
+{
+  duplicate$ is.lower.ascii
+    { pop$ #1 }
+    { latin.lower swap$ is.char.in.str }
+  if$
+}
+
+%    \end{macrocode}
+%
+% Function |is.printable.ascii| takes a UTF-8 character and checks
+% whether it is a printable ASCII character.
+%    \begin{macrocode}
+% char -> bool
+% variable used: b
+FUNCTION {is.printable.ascii}
+{
+  char.to.unicode #32 swap$ #126 swap$ is.int.in.range
+}
+
+%    \end{macrocode}
+%
+% Function |is.letter.ascii| takes a UTF-8 character and checks
+% whether it is an ASCII letter.
+%    \begin{macrocode}
+% char -> bool
+% variable used: b
+FUNCTION {is.letter.ascii}
+{
+  duplicate$ is.upper.ascii swap$ is.lower.ascii or
+}
+
+%    \end{macrocode}
+%
+% Function |is.symbol.ascii| takes a UTF-8 character and checks whether
+% it is a printable ASCII character but not an ASCII letter.
+%    \begin{macrocode}
+% char -> bool
+% variable used: b
+FUNCTION {is.symbol.ascii}
+{
+  duplicate$ is.printable.ascii swap$ is.letter.ascii not and
+}
+
+%    \end{macrocode}
+%
+% Function |is.all.lower| takes a string and checks whether every
+% character in it is lowercase in the range from |U+0000| to |U+017F|.
+%    \begin{macrocode}
+% str -> bool
+% variable used: b
+% return true if str is empty
+FUNCTION {is.all.lower}
+{
+  #1 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str is.lower
+        'skip$
+        { pop$ pop$ #0 "" }
+      if$
+    }
+  while$
+  pop$
+}
+
+% str -> bool
+% variable used: b
+FUNCTION {is.tex.str.in.title.case}
+{
+  duplicate$ "" =
+    { pop$ #0 }
+    {
+      split.first.tex.char.from.str purify$
+      duplicate$ "" =
+        { pop$ pop$ #0 }
+        {
+          split.first.char.from.str is.upper
+            {
+              duplicate$ is.all.lower
+                {
+                  empty$
+                    {
+                      duplicate$ "" =
+                        { pop$ #0 }
+                        'is.all.lower
+                      if$
+                    }
+                    'is.all.lower
+                  if$
+                }
+                { pop$ pop$ #0 }
+              if$
+            }
+            { pop$ pop$ #0}
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+% char, int -> bool
+% variables used: t, b
+FUNCTION {is.in.inter.token.chars}
+{
+  duplicate$ #0 =
+    { pop$ " " = }
+    {
+      #1 =
+        { " " range.delimiters * swap$ is.char.in.str }
+        'is.letter.ascii
+      if$
+    }
+  if$
+}
+
+% str, int -> intertoken: str, rest: str
+% variable used: t, b
+FUNCTION {skip.inter.token.chars.by}
+{
+  'b :=
+  't :=
+
+  "" t
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str
+      duplicate$ b is.in.inter.token.chars
+        { swap$ 't := * t }
+        { swap$ * 't := "" }
+      if$
+    }
+  while$
+
+  pop$ t
+}
+
+% str -> intertoken: str, rest: str
+% variable used: t, b
+FUNCTION {skip.inter.token.chars}
+{
+  #0 skip.inter.token.chars.by
+}
+
+% str -> intertoken: str, rest: str
+% variable used: t, b
+FUNCTION {skip.inter.token.command}
+{
+  duplicate$ "" =
+    { "" }
+    {
+      duplicate$ #1 #1 substring$ is.symbol.ascii
+        { split.first.char.from.str swap$ }
+        { #2 skip.inter.token.chars.by }
+     if$
+    }
+  if$
+}
+
+% cmdstr -> cmdstr
+FUNCTION {is.special.char.command}
+{
+  #2 global.max$ substring$ skip.inter.token.command
+
+  empty$
+    'skip$
+    { "is.special.char.command: cmdstr has extra components!" warning$ }
+  if$
+
+  duplicate$ duplicate$ duplicate$ duplicate$ duplicate$ duplicate$
+  "oOlLij" swap$ is.char.in.str
+  swap$ "oe" = or
+  swap$ "OE" = or
+  swap$ "ae" = or
+  swap$ "AE" = or
+  swap$ "aa" = or
+  swap$ "AA" = or
+}
+
+% str, str, char -> char
+% variable used: t
+FUNCTION {map.char}
+{
+  't :=
+  split.first.char.from.str
+  { swap$ duplicate$ "" = not }
+    {
+      swap$ t =
+        { pop$ "" t }
+        {
+          swap$ split.first.char.from.str pop$ swap$
+          split.first.char.from.str
+        }
+      if$
+    }
+  while$
+  pop$ t =
+    'get.first.char.from.str
+    { pop$ t }
+  if$
+}
+
+% char -> char
+% variables used: t, b
+FUNCTION {to.lower}
+{
+  duplicate$ is.upper.ascii
+    { chr.to.int$ #32 + int.to.chr$ }
+    { latin.lower swap$ latin.upper swap$ map.char }
+  if$
+}
+
+% char -> char
+% variables used: t, b
+FUNCTION {to.upper}
+{
+  duplicate$ is.lower.ascii
+    { chr.to.int$ #32 - int.to.chr$ }
+    { latin.upper swap$ latin.lower swap$ map.char }
+  if$
+}
+
+% str -> str
+% variables used: t, b
+FUNCTION {all.to.lower}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.lower swap$ 't := * t }
+  while$
+  *
+}
+
+% texchar -> texchar
+% variables used: t, b
+FUNCTION {command.to.lower}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+          duplicate$ is.special.char.command
+            'all.to.lower
+            'skip$
+          if$
+        }
+        'to.lower
+      if$
+    }
+  if$
+}
+
+% texchar -> texchar
+% variables used: t, b
+FUNCTION {tex.to.lower}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+        {
+          split.first.char.from.str
+          duplicate$ #92 int.to.chr$ =
+            {
+              swap$ skip.inter.token.command 't := * t
+              swap$ command.to.lower
+            }
+            'to.lower
+          if$
+          swap$ 't := * t
+        }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.lower
+      if$
+    }
+  if$
+}
+
+% str -> str
+% variables used: t, b
+FUNCTION {all.to.upper}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.upper swap$ 't := * t }
+  while$
+  *
+}
+
+% texchar -> texchar
+% variables used: t, b
+FUNCTION {command.to.upper}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+           duplicate$ is.special.char.command
+             'all.to.upper
+             'skip$
+           if$
+        }
+        'to.upper
+      if$
+    }
+  if$
+}
+
+% texchar -> texchar
+% variables used: t, b
+FUNCTION {tex.to.upper}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+      {
+        split.first.char.from.str
+        duplicate$ #92 int.to.chr$ =
+          {
+            swap$ skip.inter.token.command 't := * t
+            swap$ command.to.upper
+          }
+          'to.upper
+        if$
+        swap$ 't := * t
+      }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.upper
+      if$
+    }
+  if$
+}
+
+% texstr -> texstr
+% variable used: t, b
+FUNCTION {lower.token.if.in.title.case}
+{
+  duplicate$ is.tex.str.in.title.case
+    { split.first.tex.char.from.str tex.to.lower swap$ * }
+    'skip$
+  if$
+}
+
+% int -> str
+FUNCTION {self.tokens}
+{
+  #0 =
+    'default.self.tokens
+    'range.delimiters
+  if$
+}
+
+% str, int -> token: str, rest: str
+% variables used: s, t, b
+FUNCTION {tokenize.by}
+{
+  'b :=
+  's :=
+
+  s "" =
+    { "" "" }
+    {
+      s split.first.char.from.str
+      duplicate$ b self.tokens swap$ is.char.in.str
+        'swap$
+        {
+          duplicate$ #92 int.to.chr$ =
+            { swap$ skip.inter.token.command 's := * s }
+            {
+              pop$ pop$ "" s
+              { duplicate$ "" = not }
+                {
+                  split.first.char.from.str
+                  duplicate$ "\ " b self.tokens * swap$ is.char.in.str
+                    { pop$ pop$ "" }
+                    {
+                      duplicate$ "{" =
+                        { swap$ find.match.brace }
+                        'swap$
+                      if$
+                      's := * s
+                    }
+                  if$
+                }
+              while$
+              pop$ s
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+% str -> str
+% variables used: s, t, b
+FUNCTION {tokenize}
+{
+  #0 tokenize.by
+}
+
+% str -> str
+% variables used: s, t, b
+FUNCTION {smart.sentence.case}
+{
+  tokenize 's :=
+
+  { s "" = not }
+    {
+      s skip.inter.token.chars 's := * s
+      tokenize swap$
+      duplicate$ ":" =
+        {
+          swap$ 's := *
+          s skip.inter.token.chars 's := * s
+          tokenize swap$
+          lowercase.word.after.colon
+            {
+              duplicate$ "A" =
+                { pop$ "a" }
+                'lower.token.if.in.title.case
+              if$
+            }
+            'skip$
+          if$
+        }
+        'lower.token.if.in.title.case
+      if$
+      swap$ 's := *
+    }
+  while$
+}
+
+% str -> str
+% variables used: s, t, b
+FUNCTION {smart.upper.case}
+{
+  s swap$ t swap$
+
+  "" swap$
+  { duplicate$ "" = not }
+    {
+      tokenize swap$
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        'command.to.upper
+        {
+          "" swap$
+          { duplicate$ "" = not }
+            {
+              split.first.tex.char.from.str tex.to.upper
+              swap$ 't := * t
+            }
+          while$
+          pop$
+        }
+      if$
+      swap$ 't := * t
+      skip.inter.token.chars 't := * t
+    }
+  while$
+  pop$
+
+  swap$ 't :=
+  swap$ 's :=
 }
 
 %    \end{macrocode}
@@ -2136,7 +2956,7 @@ FUNCTION {format.name}
       name.lang lang.en =
         { t #1 "{vv~}{ll}{ f{~}}" format.name$
           uppercase.name
-            { "u" change.case$ }
+            'smart.upper.case
             'skip$
           if$
           t #1 "{, jj}" format.name$ *
@@ -2330,7 +3150,7 @@ FUNCTION {output.bibitem}
 %    \begin{macrocode}
 FUNCTION {change.sentence.case}
 { entry.lang lang.en =
-    { "t" change.case$ }
+    'smart.sentence.case
     'skip$
   if$
 }
@@ -3085,25 +3905,24 @@ FUNCTION {format.urldate}
 %
 % 国标里页码范围的连接号使用 hyphen，需要将 dash 转为 hyphen。
 %    \begin{macrocode}
-FUNCTION {hyphenate}
-{ 't :=
-  ""
-    { t empty$ not }
-    { t #1 #1 substring$ "-" =
-        { wave.dash.in.pages
-            { "～" * }
-            { "-" * }
-          if$
-            { t #1 #1 substring$ "-" = }
-            { t #2 global.max$ substring$ 't := }
-          while$
-        }
-        { t #1 #1 substring$ *
-          t #2 global.max$ substring$ 't :=
-        }
+% str -> str
+% variable used: s, t, b
+FUNCTION {normalize.page.range}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    {
+      #1 skip.inter.token.chars.by 't :=
+      empty$
+        { "" }
+        'page.range.delimiter
       if$
+      * t
+      #1 tokenize.by 't :=
+      * t
     }
   while$
+  pop$
 }
 
 %    \end{macrocode}
@@ -3112,10 +3931,8 @@ FUNCTION {hyphenate}
 % Other functions that use this should keep that in mind.
 %    \begin{macrocode}
 FUNCTION {format.pages}
-{ pages empty$
-    { "" }
-    { pages hyphenate }
-  if$
+{
+  pages normalize.page.range
 }
 
 FUNCTION {format.extracted.pages}
@@ -3123,8 +3940,8 @@ FUNCTION {format.extracted.pages}
     { "" }
     { pages
       only.start.page
-        'extract.before.dash
-        'hyphenate
+        { #1 tokenize.by pop$ }
+        'normalize.page.range
       if$
     }
   if$

--- a/test/testbst/2015-author-year.bbl
+++ b/test/testbst/2015-author-year.bbl
@@ -584,7 +584,7 @@ BAKER S~K, JACKSON M~E, 1995.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P, 2011.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -639,7 +639,7 @@ CRANE D, 1972.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M, 1995.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association.
 
 \bibitem[Des~Marais et~al.(1992)Des~Marais, Strauss, Summons, et~al.]{A.8:5}
@@ -657,7 +657,7 @@ DEVERELL W, IGLER D, 2013.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L, 1995.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 21\allowbreak (1/2): 5-26.
 
@@ -694,14 +694,14 @@ FRESE K~S, KATUS H~A, MEDER B, 2013.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A, 2009.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}, 1977.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC.
@@ -759,14 +759,14 @@ O'BRIEN J~A, 1994.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}, [2012].
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y, 2010.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock
@@ -852,13 +852,13 @@ SODEMAN W~A, Jr, SODEMAN W~A.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}, 1970.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A, 2000.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].

--- a/test/testbst/2015-numerical.bbl
+++ b/test/testbst/2015-numerical.bbl
@@ -98,7 +98,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -106,7 +106,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -300,13 +300,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -359,7 +359,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -519,13 +519,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -613,7 +613,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -798,7 +798,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/option-2005-author-year.bbl
+++ b/test/testbst/option-2005-author-year.bbl
@@ -572,7 +572,7 @@ BAKER S~K, JACKSON M~E. 1995.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P. 2011.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -627,7 +627,7 @@ CRANE D. 1972.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M. 1995.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association.
 
 \bibitem[Des~Marais et~al.(1992)Des~Marais, Strauss, Summons, et~al.]{A.8:5}
@@ -645,7 +645,7 @@ DEVERELL W, IGLER D. 2013.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L. 1995.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 21\allowbreak (1/2): 5-26.
 
@@ -681,14 +681,14 @@ FRESE K~S, KATUS H~A, MEDER B. 2013.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A. 2009.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}. 1977.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC.
@@ -745,14 +745,14 @@ O'BRIEN J~A. 1994.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}. [2012].
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y. 2010.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock
@@ -837,13 +837,13 @@ SODEMAN W~A, Jr, SODEMAN W~A.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}. 1970.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A. 2000.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].

--- a/test/testbst/option-2005-numerical.bbl
+++ b/test/testbst/option-2005-numerical.bbl
@@ -103,7 +103,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -111,7 +111,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -303,13 +303,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -361,7 +361,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -521,13 +521,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -615,7 +615,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -798,7 +798,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/option-in-collection.bbl
+++ b/test/testbst/option-in-collection.bbl
@@ -98,7 +98,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -106,7 +106,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -297,13 +297,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -356,7 +356,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -515,13 +515,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -609,7 +609,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -792,7 +792,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/option-italic-journal.bbl
+++ b/test/testbst/option-italic-journal.bbl
@@ -98,7 +98,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -106,7 +106,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -301,13 +301,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -360,7 +360,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock \emph{Journal of library administration}, 1995, 21\allowbreak (1/2):
   5-26.
@@ -522,13 +522,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -616,7 +616,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -803,7 +803,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock \emph{Cataloging \& classification quarterly}, 2010, 48\allowbreak
   (8): 696-715\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/option-link-jounal.bbl
+++ b/test/testbst/option-link-jounal.bbl
@@ -98,7 +98,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -106,7 +106,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -308,13 +308,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -367,7 +367,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -529,13 +529,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -623,7 +623,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -811,7 +811,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock
   \href{http://www.tandfonline.com/doi/pdf/10.1080/01639374.2010.508711}{Cataloging
   \& classification quarterly}, 2010, 48\allowbreak (8):

--- a/test/testbst/option-link-title.bbl
+++ b/test/testbst/option-link-title.bbl
@@ -103,7 +103,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -112,7 +112,7 @@ YUFIN S~A.
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
 \newblock \href{http://lib.myilibrary.com/Open.aspx?id=312377}{Developing early
-  childhood services: Past, present and future}\allowbreak[M/OL].
+  childhood services: past, present and future}\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
 
@@ -321,14 +321,14 @@ BAWDEN D.
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
 \newblock \href{http://www.oclc.org/about/cooperation.en.html}{About {OCLC}:
-  History of cooperation}\allowbreak[EB/OL].
+  history of cooperation}\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock \href{http://archive.ifla.org/IV/ifla64/138-161e.htm}{{UNIMARC} and
-  metadata: Dublin core}\allowbreak[EB/OL].
+\newblock \href{http://archive.ifla.org/IV/ifla64/138-161e.htm}{UNIMARC and
+  metadata: {Dublin Core}}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -383,7 +383,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -546,13 +546,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -643,7 +643,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -839,7 +839,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 PARK J~R, TOSAKA Y.
 \newblock
   \href{http://www.tandfonline.com/doi/pdf/10.1080/01639374.2010.508711}{Metadata
-  quality control in digital repositories and collections: Criteria, semantics,
+  quality control in digital repositories and collections: criteria, semantics,
   and mechanisms}\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].

--- a/test/testbst/option-macro.bbl
+++ b/test/testbst/option-macro.bbl
@@ -101,7 +101,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -109,7 +109,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -305,13 +305,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -364,7 +364,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -526,13 +526,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford {\bibetal}(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -621,7 +621,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -807,7 +807,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park {\bibetal}(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/option-no-doi.bbl
+++ b/test/testbst/option-no-doi.bbl
@@ -98,7 +98,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -106,7 +106,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -297,13 +297,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -355,7 +355,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -515,13 +515,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -609,7 +609,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -792,7 +792,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/option-no-mark.bbl
+++ b/test/testbst/option-no-mark.bbl
@@ -97,14 +97,14 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4, 2000.
 \newblock Rotterdam: A. A. Balkema, 2000.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and future.
+\newblock Developing early childhood services: past, present and future.
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
 
@@ -291,13 +291,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation.
+\newblock About {OCLC}: history of cooperation.
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core.
+\newblock UNIMARC and metadata: {Dublin Core}.
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -348,7 +348,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment.
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -505,13 +505,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality.
+\newblock Future libraries: dreams, madness, \& reality.
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in catalogues.
+\newblock Names of persons: national usages for entry in catalogues.
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
 
@@ -594,7 +594,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}.
 \newblock Geneva: WHO, 1970.
 
@@ -773,7 +773,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms.
+  criteria, semantics, and mechanisms.
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/option-no-medium-type.bbl
+++ b/test/testbst/option-no-medium-type.bbl
@@ -98,7 +98,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -106,7 +106,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -298,13 +298,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -357,7 +357,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -517,13 +517,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -610,7 +610,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -795,7 +795,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J].
+  criteria, semantics, and mechanisms\allowbreak[J].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/option-no-sentence-case.bbl
+++ b/test/testbst/option-no-sentence-case.bbl
@@ -306,7 +306,7 @@ BAWDEN D.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and Metadata: Dublin Core\allowbreak[EB/OL].
+\newblock UNIMARC and Metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 

--- a/test/testbst/option-no-slash.bbl
+++ b/test/testbst/option-no-slash.bbl
@@ -98,7 +98,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -106,7 +106,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -297,13 +297,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -356,7 +356,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -515,13 +515,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -609,7 +609,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -792,7 +792,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/option-no-uppercase.bbl
+++ b/test/testbst/option-no-uppercase.bbl
@@ -98,7 +98,7 @@ Peebles P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 Yufin S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -106,7 +106,7 @@ Yufin S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 Baldock P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -300,13 +300,13 @@ Bawden D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 Hopkinson A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -359,7 +359,7 @@ Chernik B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 Dowler L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -519,13 +519,13 @@ Kennedy W~L, Garrison R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 Crawford W, Gorman M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -613,7 +613,7 @@ Calkin D, Ager A, Thompson M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -798,7 +798,7 @@ Franz A~K, Danielewicz M~A, Wong D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 Park J~R, Tosaka Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/option-no-url-doi.bbl
+++ b/test/testbst/option-no-url-doi.bbl
@@ -92,7 +92,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -100,7 +100,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M].
 \newblock Rotterdam: Open University Press, 2011: 105.
 
@@ -269,13 +269,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -323,7 +323,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -479,13 +479,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -565,7 +565,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -731,7 +731,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J].
+  criteria, semantics, and mechanisms\allowbreak[J].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715.
 

--- a/test/testbst/option-no-url.bbl
+++ b/test/testbst/option-no-url.bbl
@@ -92,7 +92,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -100,7 +100,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M].
 \newblock Rotterdam: Open University Press, 2011: 105.
 
@@ -272,13 +272,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -328,7 +328,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -484,13 +484,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -570,7 +570,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -738,7 +738,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J].
+  criteria, semantics, and mechanisms\allowbreak[J].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715.
 

--- a/test/testbst/option-no-urldate.bbl
+++ b/test/testbst/option-no-urldate.bbl
@@ -98,7 +98,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -106,7 +106,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105.
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -298,13 +298,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -357,7 +357,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -517,13 +517,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -610,7 +610,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -794,7 +794,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715.
 \newblock

--- a/test/testbst/option-only-start-page.bbl
+++ b/test/testbst/option-only-start-page.bbl
@@ -98,7 +98,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -106,7 +106,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -300,13 +300,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -359,7 +359,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5.
 
@@ -519,13 +519,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -613,7 +613,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -797,7 +797,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/option-preprint.bbl
+++ b/test/testbst/option-preprint.bbl
@@ -13,7 +13,7 @@
 
 \bibitem[Kingma et~al.(2014)Kingma and Ba]{kingma2014adam}
 KINGMA D~P, BA J.
-\newblock Adam: A method for stochastic optimization\allowbreak[A/OL].
+\newblock Adam: a method for stochastic optimization\allowbreak[A/OL].
 \newblock 2014\allowbreak[2017-04-19].
 \newblock arXiv: \eprint{http://arxiv.org/abs/1412.6980}{1412.6980}.
 \newblock \url{http://arxiv.org/abs/1412.6980}.
@@ -113,7 +113,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -121,7 +121,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -315,13 +315,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -374,7 +374,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -534,13 +534,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -628,7 +628,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -813,7 +813,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/option-short-journal.bbl
+++ b/test/testbst/option-short-journal.bbl
@@ -106,7 +106,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -114,7 +114,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -308,13 +308,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -367,7 +367,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -527,13 +527,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -621,7 +621,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -806,7 +806,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/option-sl-sn.bbl
+++ b/test/testbst/option-sl-sn.bbl
@@ -98,7 +98,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -106,7 +106,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -300,13 +300,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -359,7 +359,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -519,13 +519,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -613,7 +613,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -798,7 +798,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/support/standard.bib
+++ b/test/testbst/support/standard.bib
@@ -466,7 +466,7 @@
 
 @online{4.6.2:5,
   author       = {Hopkinson, A},
-  title        = {{UNIMARC} and Metadata: Dublin Core},
+  title        = {UNIMARC and Metadata: {Dublin Core}},
   year         = {2009},
   date         = {2009-04-22},
   urldate      = {2013-03-27},

--- a/test/testbst/thu-numeric.bbl
+++ b/test/testbst/thu-numeric.bbl
@@ -24,7 +24,7 @@
 \bibitem[Dupont(1974)]{10-1:3}
 Dupont B.
 \newblock Bone marrow transplantation in severe combined immunodeficiency with
-  an unrelated mlc compatible donor\allowbreak[C]//\allowbreak
+  an unrelated MLC compatible donor\allowbreak[C]//\allowbreak
 White H~J, Smith R.
 \newblock Proceedings of the third annual meeting of the International Society
   for Experimental Hematology.
@@ -103,7 +103,7 @@ Atkinson J~B, Becker J, Demtr{\"o}der W.
 
 \bibitem[Kusch et~al.(1975)Kusch and Hessel]{10-1:16}
 Kusch P, Hessel M~M.
-\newblock Perturbations in the a {1$\Sigma$u+} state of {Na2}\allowbreak[J].
+\newblock Perturbations in the A {1$\Sigma$u+} state of {Na2}\allowbreak[J].
 \newblock J Chem Phys, 1975, 63: 4087-4088.
 
 \bibitem[广西壮族自治区林业厅(1993)]{10-1:17}
@@ -143,7 +143,7 @@ Kusch P, Hessel M~M.
 
 \bibitem[{World Health Organization}(1970)]{10-1:23}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -209,7 +209,7 @@ Sodeman W~A, Jr, Sodeman W~A.
 
 \bibitem[{Online Computer Library Center, Inc}({[2000]})]{10-1:33}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2000-01-08].
 \newblock \url{http://www.oclc.org/about/cooperation.en.htm}.
 

--- a/test/testbst/ucas-author-year.bbl
+++ b/test/testbst/ucas-author-year.bbl
@@ -586,7 +586,7 @@ BAKER S~K, JACKSON M~E.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -642,7 +642,7 @@ CRANE D.
 
 \bibitem[Crawford{\biband}Gorman(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[Des~Marais {\bibetal}(1992)Des~Marais, Strauss, Summons,
@@ -661,7 +661,7 @@ DEVERELL W, IGLER D.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -698,14 +698,14 @@ FRESE K~S, KATUS H~A, MEDER B.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -765,14 +765,14 @@ O'BRIEN J~A.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Park{\biband}Tosaka(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock
@@ -858,13 +858,13 @@ SODEMAN W~A, Jr, SODEMAN W~A.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].

--- a/test/testbst/ucas-numerical.bbl
+++ b/test/testbst/ucas-numerical.bbl
@@ -100,7 +100,7 @@ PEEBLES P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -108,7 +108,7 @@ YUFIN S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press, 2011: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -304,13 +304,13 @@ BAWDEN D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -363,7 +363,7 @@ CHERNIK B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -525,13 +525,13 @@ KENNEDY W~L, GARRISON R~E.
 
 \bibitem[Crawford{\biband}Gorman(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -620,7 +620,7 @@ CALKIN D, AGER A, THOMPSON M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -806,7 +806,7 @@ FRANZ A~K, DANIELEWICZ M~A, WONG D~M, et~al.
 \bibitem[Park{\biband}Tosaka(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock

--- a/test/testbst/ustc-author-year.bbl
+++ b/test/testbst/ustc-author-year.bbl
@@ -523,7 +523,7 @@ Baker S~K, Jackson M~E, 1995.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 Baldock P, 2011.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M].
 \newblock Rotterdam: Open University Press: 105.
 
@@ -577,7 +577,7 @@ Crane D, 1972.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 Crawford W, Gorman M, 1995.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association.
 
 \bibitem[Des~Marais et~al.(1992)Des~Marais, Strauss, Summons, et~al.]{A.8:5}
@@ -593,7 +593,7 @@ Deverell W, Igler D, 2013.
 
 \bibitem[Dowler(1995)]{9.1:6}
 Dowler L, 1995.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 21\allowbreak (1/2): 5-26.
 
@@ -625,14 +625,14 @@ Frese K~S, Katus H~A, Meder B, 2013.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 Hopkinson A, 2009.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}, 1977.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC.
@@ -684,14 +684,14 @@ O'Brien J~A, 1994.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}, [2012].
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 Park J~R, Tosaka Y, 2010.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J].
+  criteria, semantics, and mechanisms\allowbreak[J].
 \newblock Cataloging \& classification quarterly, 48\allowbreak (8): 696-715.
 
 \bibitem[Peebles(2001)]{4.1.2:14}
@@ -765,13 +765,13 @@ Sodeman W~A, Jr, Sodeman W~A.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}, 1970.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 Yufin S~A, 2000.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].

--- a/test/testbst/ustc-numerical.bbl
+++ b/test/testbst/ustc-numerical.bbl
@@ -92,7 +92,7 @@ Peebles P~Z, Jr.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 Yufin S~A.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].
@@ -100,7 +100,7 @@ Yufin S~A.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 Baldock P.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M].
 \newblock Rotterdam: Open University Press, 2011: 105.
 
@@ -269,13 +269,13 @@ Bawden D.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}.
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 Hopkinson A.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
@@ -323,7 +323,7 @@ Chernik B~E.
 
 \bibitem[Dowler(1995)]{9.1:6}
 Dowler L.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 1995, 21\allowbreak (1/2): 5-26.
 
@@ -479,13 +479,13 @@ Kennedy W~L, Garrison R~E.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 Crawford W, Gorman M.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association, 1995.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC, 1977.
@@ -565,7 +565,7 @@ Calkin D, Ager A, Thompson M.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO, 1970.
 
@@ -731,7 +731,7 @@ Franz A~K, Danielewicz M~A, Wong D~M, et~al.
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 Park J~R, Tosaka Y.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J].
+  criteria, semantics, and mechanisms\allowbreak[J].
 \newblock Cataloging \& classification quarterly, 2010, 48\allowbreak (8):
   696-715.
 

--- a/test/testbst/year-suffix-overflow.bbl
+++ b/test/testbst/year-suffix-overflow.bbl
@@ -619,19 +619,19 @@ Anon, 1981.
 
 \bibitem[ch9({\natexlab{k}})]{ch9-1}
 Anon.
-\newblock Elios 2\allowbreak[Z].
+\newblock ELIOS 2\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{l}})]{ch9-10}
 Anon.
-\newblock Cw-10\allowbreak[Z].
+\newblock CW-10\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{m}})]{ch9-11}
 Anon.
-\newblock Jouav\allowbreak[Z].
+\newblock JOUAV\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{n}})]{ch9-12}
 Anon.
-\newblock X-hawk\allowbreak[Z].
+\newblock X-HAWK\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{o}})]{ch9-13}
 Anon.
@@ -639,7 +639,7 @@ Anon.
 
 \bibitem[ch9({\natexlab{p}})]{ch9-15}
 Anon.
-\newblock Vertikul 2\allowbreak[Z].
+\newblock VERTIKUL 2\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{q}})]{ch9-16}
 Anon.
@@ -655,7 +655,7 @@ Anon.
 
 \bibitem[ch9({\natexlab{t}})]{ch9-19}
 Anon.
-\newblock The hexh2o\allowbreak[Z].
+\newblock The HexH2o\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{u}})]{ch9-21}
 Anon.
@@ -671,7 +671,7 @@ Anon.
 
 \bibitem[ch9({\natexlab{x}})]{ch9-29}
 Anon.
-\newblock Volocity\allowbreak[Z].
+\newblock VoloCity\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{y}})]{ch9-30}
 Anon.
@@ -679,23 +679,23 @@ Anon.
 
 \bibitem[ch9({\natexlab{z}})]{ch9-34}
 Anon.
-\newblock Exynaero\allowbreak[Z].
+\newblock ExynAero\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{aa}})]{ch9-35}
 Anon.
-\newblock Gpr+drone integrated system\allowbreak[Z].
+\newblock GPR+DRONE INTEGRATED SYSTEM\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{ab}})]{ch9-37}
 Anon.
-\newblock Bug\allowbreak[Z].
+\newblock BUG\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{ac}})]{ch9-38}
 Anon.
-\newblock Songar\allowbreak[Z].
+\newblock SONGAR\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{ad}})]{ch9-39}
 Anon.
-\newblock Lmadis\allowbreak[Z].
+\newblock LMADIS\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{ae}})]{ch9-4}
 Anon.
@@ -707,15 +707,15 @@ Anon.
 
 \bibitem[ch9({\natexlab{ag}})]{ch9-41}
 Anon.
-\newblock Dronekiller\allowbreak[Z].
+\newblock DRONEKILLER\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{ah}})]{ch9-42}
 Anon.
-\newblock Athena\allowbreak[Z].
+\newblock ATHENA\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{ai}})]{ch9-43}
 Anon.
-\newblock Clws\allowbreak[Z].
+\newblock CLWS\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{aj}})]{ch9-44}
 Anon.
@@ -723,11 +723,11 @@ Anon.
 
 \bibitem[ch9({\natexlab{ak}})]{ch9-45}
 Anon.
-\newblock Auds\allowbreak[Z].
+\newblock AUDS\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{al}})]{ch9-46}
 Anon.
-\newblock Dronebullet\allowbreak[Z].
+\newblock DRONEBULLET\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{am}})]{ch9-47}
 Anon.
@@ -735,24 +735,24 @@ Anon.
 
 \bibitem[ch9({\natexlab{an}})]{ch9-48}
 Anon.
-\newblock Dronehunter\allowbreak[Z].
+\newblock DroneHunter\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{ao}})]{ch9-49}
 Anon.
-\newblock Flying squad amazing moment golden eagle tackles drone in mid-air as
+\newblock FLYING SQUAD amazing moment golden eagle tackles drone in mid-air as
   military chiefs train birds of prey to keep skies safe\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{ap}})]{ch9-5}
 Anon.
-\newblock Skyty\allowbreak[Z].
+\newblock SkyTy\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{aq}})]{ch9-58}
 Anon.
-\newblock Cityairbus\allowbreak[Z].
+\newblock CityAirbus\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{ar}})]{ch9-6}
 Anon.
-\newblock Mk destiny\allowbreak[Z].
+\newblock MK destiny\allowbreak[Z].
 
 \bibitem[ch9({\natexlab{as}})]{ch9-8}
 Anon.
@@ -760,7 +760,7 @@ Anon.
 
 \bibitem[ch9({\natexlab{at}})]{ch9-9}
 Anon.
-\newblock Cw-30\allowbreak[Z].
+\newblock CW-30\allowbreak[Z].
 
 \bibitem[A.6(2009)]{A.6:4}
 Anon, 2009.
@@ -789,7 +789,7 @@ BAKER S~K, JACKSON M~E, 1995.
 
 \bibitem[Baldock(2011)]{4.1.2:16}
 BALDOCK P, 2011.
-\newblock Developing early childhood services: Past, present and
+\newblock Developing early childhood services: past, present and
   future\allowbreak[M/OL].
 \newblock Rotterdam: Open University Press: 105\allowbreak[2012-11-27].
 \newblock \url{http://lib.myilibrary.com/Open.aspx?id=312377}.
@@ -844,7 +844,7 @@ CRANE D, 1972.
 
 \bibitem[Crawford et~al.(1995)Crawford and Gorman]{A.1:12}
 CRAWFORD W, GORMAN M, 1995.
-\newblock Future libraries: Dreams, madness, \& reality\allowbreak[M].
+\newblock Future libraries: dreams, madness, \& reality\allowbreak[M].
 \newblock Chicago: American Library Association.
 
 \bibitem[Des~Marais et~al.(1992)Des~Marais, Strauss, Summons, et~al.]{A.8:5}
@@ -869,14 +869,14 @@ DING D, HAN Q~L, XIANG Y, et~al., 2018.
 
 \bibitem[Dowler(1995)]{9.1:6}
 DOWLER L, 1995.
-\newblock The research university's dilemma: Resource sharing and research in a
+\newblock The research university's dilemma: resource sharing and research in a
   transinstitutional environment\allowbreak[J].
 \newblock Journal of library administration, 21\allowbreak (1/2): 5-26.
 
 \bibitem[Falanga et~al.(2019)Falanga, Kleber, Mintchev, Floreano, and
   Scaramuzza]{ch9-2}
 FALANGA D, KLEBER K, MINTCHEV S, et~al., 2019.
-\newblock The foldable drone: A morphing quadrotor that can squeeze and
+\newblock The foldable drone: a morphing quadrotor that can squeeze and
   fly\allowbreak[J/OL].
 \newblock IEEE Robotics and Automation Letters, 4\allowbreak (2): 209-216.
 \newblock DOI: \doi{10.1109/LRA.2018.2885575}.
@@ -914,14 +914,14 @@ FRESE K~S, KATUS H~A, MEDER B, 2013.
 
 \bibitem[Hopkinson(2009)]{4.6.2:5}
 HOPKINSON A, 2009.
-\newblock {UNIMARC} and metadata: Dublin core\allowbreak[EB/OL].
+\newblock UNIMARC and metadata: {Dublin Core}\allowbreak[EB/OL].
 \newblock \allowbreak(2009-04-22)\allowbreak[2013-03-27].
 \newblock \url{http://archive.ifla.org/IV/ifla64/138-161e.htm}.
 
 \bibitem[{International Federation of Library Association and
   Institutions}(1977)]{A.1:13}
 {International Federation of Library Association and Institutions}, 1977.
-\newblock Names of persons: National usages for entry in
+\newblock Names of persons: national usages for entry in
   catalogues\allowbreak[M].
 \newblock 3rd ed.
 \newblock London: IFLA International Office for UBC.
@@ -929,7 +929,7 @@ HOPKINSON A, 2009.
 \bibitem[Kamel et~al.(2018)Kamel, Verling, Elkhatib, Sprecher, Wulkop, Taylor,
   Siegwart, and Gilitschenski]{ch9-3}
 KAMEL M~S, VERLING S, ELKHATIB O, et~al., 2018.
-\newblock Voliro: An omnidirectional hexacopter with tiltable
+\newblock Voliro: an omnidirectional hexacopter with tiltable
   rotors\allowbreak[J/OL].
 \newblock IEEE Robotics and Automation Magazine, abs/18/01,04581\allowbreak
   (4): 33-34.
@@ -988,14 +988,14 @@ O'BRIEN J~A, 1994.
 
 \bibitem[{Online Computer Library Center, Inc}({[2012]})]{4.6.2:4}
 {Online Computer Library Center, Inc}, [2012].
-\newblock About {OCLC}: History of cooperation\allowbreak[EB/OL].
+\newblock About {OCLC}: history of cooperation\allowbreak[EB/OL].
 \newblock \allowbreak[2012-03-27].
 \newblock \url{http://www.oclc.org/about/cooperation.en.html}.
 
 \bibitem[Park et~al.(2010)Park and Tosaka]{A.8:9}
 PARK J~R, TOSAKA Y, 2010.
 \newblock Metadata quality control in digital repositories and collections:
-  Criteria, semantics, and mechanisms\allowbreak[J/OL].
+  criteria, semantics, and mechanisms\allowbreak[J/OL].
 \newblock Cataloging \& classification quarterly, 48\allowbreak (8):
   696-715\allowbreak[2013-09-05].
 \newblock
@@ -1087,19 +1087,19 @@ SODEMAN W~A, Jr, SODEMAN W~A.
 
 \bibitem[{World Health Organization}(1970)]{A.3:5}
 {World Health Organization}, 1970.
-\newblock Factors regulating the immune response: Report of {WHO Scientific
+\newblock Factors regulating the immune response: report of {WHO Scientific
   Group}\allowbreak[R].
 \newblock Geneva: WHO.
 
 \bibitem[Xiao et~al.(2021)Xiao, Meng, Dai, Zhang, and Quan]{ch9-14}
 XIAO K, MENG Y, DAI X, et~al., 2021.
-\newblock A lifting wing fixed on multirotor uavs for long flight
+\newblock A lifting wing fixed on multirotor UAVs for long flight
   ranges\allowbreak[J].
 \newblock 2021 International Conference on Unmanned Aircraft Systems.
 
 \bibitem[Yufin(2000)]{4.1.2:15}
 YUFIN S~A, 2000.
-\newblock Geoecology and computers: Proceedings of the {Third International
+\newblock Geoecology and computers: proceedings of the {Third International
   Conference on Advances of Computer Methods in Geotechnical and
   Geoenvironmental Engineering}, {Moscow, Russia}, {February} 1--4,
   2000\allowbreak[C].

--- a/variants/thu/thuthesis-author-year.bst
+++ b/variants/thu/thuthesis-author-year.bst
@@ -44,7 +44,6 @@ INTEGERS {
   show.missing.address.publisher
   space.before.pages
   only.start.page
-  wave.dash.in.pages
   show.urldate
   show.url
   show.doi
@@ -52,6 +51,7 @@ INTEGERS {
   show.note
   show.english.translation
   end.with.period
+  lowercase.word.after.colon
   lang.zh.order
   lang.ja.order
   lang.en.order
@@ -61,6 +61,7 @@ INTEGERS {
 
 STRINGS {
   component.part.label
+  page.range.delimiter
 }
 
 FUNCTION {load.config}
@@ -89,7 +90,7 @@ FUNCTION {load.config}
   #0 'show.missing.address.publisher :=
   #1 'space.before.pages :=
   #0 'only.start.page :=
-  #0 'wave.dash.in.pages :=
+  "-" 'page.range.delimiter :=
   #1 'show.urldate :=
   #1 'show.url :=
   #1 'show.doi :=
@@ -97,6 +98,7 @@ FUNCTION {load.config}
   #0 'show.note :=
   #0 'show.english.translation :=
   #1 'end.with.period :=
+  #1 'lowercase.word.after.colon :=
   #1 'lang.zh.order :=
   #2 'lang.ja.order :=
   #3 'lang.en.order :=
@@ -243,6 +245,14 @@ FUNCTION {bbl.sine.loco.sine.nomine}
     { "[S.l.: s.n.]" }
   if$
 }
+
+FUNCTION {default.self.tokens} { ":,-'–—?.!" }
+
+FUNCTION {latin.upper} { "ÀÁÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİIĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ" }
+
+FUNCTION {latin.lower} { "àáãäåæçèéêëìíîïðñòóôõöøùúûüýþÿāăąćĉċčďđēĕėęěĝğġģĥħĩīĭįiıĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" }
+
+FUNCTION {range.delimiters} { "-–—～" }
 
 FUNCTION {not}
 {   { #0 }
@@ -449,6 +459,619 @@ FUNCTION {new.sentence.checkb}
   if$
 }
 
+INTEGERS { b }
+
+FUNCTION {is.int.in.range}
+{
+  'b :=
+  #1 +
+  b >
+    { #1 - b < }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {mult.power2}
+{
+  { duplicate$ #0 > }
+    {
+      swap$
+      duplicate$ +
+      swap$ #1 -
+    }
+  while$
+  pop$
+}
+
+FUNCTION {find.match.brace}
+{
+  's :=
+  't :=
+
+  #1
+  { duplicate$ #0 >
+    s empty$ not and }
+    {
+      s #1 #1 substring$ "{" =
+        { #1 + }
+        {
+          s #1 #1 substring$ "}" =
+            { #1 - }
+            'skip$
+          if$
+        }
+      if$
+      t s #1 #1 substring$ * 't :=
+      s #2 global.max$ substring$ 's :=
+    }
+  while$
+
+  duplicate$ #0 >
+    {
+      "Unbalanced brace(s): one or more closing braces are missing" warning$
+      { duplicate$ #0 > }
+        {
+          t "}" * 't :=
+          #1 -
+        }
+      while$
+    }
+    'skip$
+  if$
+  pop$
+
+  t
+  s
+}
+
+FUNCTION {split.first.char.from.str}
+{
+  duplicate$ "" =
+    {
+      "split.first.char.from.str: Trying to split an empty string!" warning$
+      ""
+    }
+    {
+      duplicate$ #1 #1 substring$ chr.to.int$ #128 <
+        {
+          duplicate$ #1 #1 substring$ swap$
+          #2 global.max$ substring$ swap$
+        }
+        {
+          duplicate$ #1 #1 substring$ chr.to.int$ #224 <
+            {
+              duplicate$ #1 #2 substring$ swap$
+              #3 global.max$ substring$ swap$
+            }
+            {
+              duplicate$ #1 #1 substring$ chr.to.int$ #240 <
+                {
+                  duplicate$ #1 #3 substring$ swap$
+                  #4 global.max$ substring$ swap$
+                }
+                {
+                  duplicate$ #1 #4 substring$ swap$
+                  #5 global.max$ substring$ swap$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {get.first.char.from.str}
+{
+  split.first.char.from.str swap$ pop$
+}
+
+FUNCTION {split.first.tex.char.from.str}
+{
+  duplicate$ #1 #1 substring$ "{" =
+    {
+      split.first.char.from.str swap$
+      find.match.brace swap$
+    }
+    'split.first.char.from.str
+  if$
+}
+
+FUNCTION {char.to.unicode}
+{
+  duplicate$ #4 #1 substring$ "" =
+    {
+      duplicate$ #3 #1 substring$ "" =
+        {
+          duplicate$ #2 #1 substring$ "" =
+            {
+              duplicate$ "" =
+                {
+                  "Empty string is not a char!" warning$
+                  pop$ #-1
+                }
+                { #1 #1 substring$ chr.to.int$ }
+              if$
+            }
+            {
+              duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+              #1 #1 substring$ chr.to.int$ #192 -
+              #6 mult.power2 +
+            }
+          if$
+        }
+        {
+          duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+          duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+          #1 #1 substring$ chr.to.int$ #224 -
+          #6 mult.power2 +
+          #6 mult.power2 +
+        }
+      if$
+    }
+    {
+      duplicate$ #4 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+      #1 #1 substring$ chr.to.int$ #240 -
+      #6 mult.power2 +
+      #6 mult.power2 +
+      #6 mult.power2 +
+    }
+  if$
+}
+
+FUNCTION {is.char.in.str}
+{
+  't :=
+
+  t "" =
+    { "is.char.in.str: Empty string is not a char!" warning$ }
+    'skip$
+  if$
+
+  #0 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str t =
+        { pop$ pop$ #1 "" }
+        'skip$
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.upper.ascii}
+{
+  char.to.unicode #65 swap$ #90 swap$ is.int.in.range
+}
+
+FUNCTION {is.upper}
+{
+  duplicate$ is.upper.ascii
+    { pop$ #1 }
+    { latin.upper swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.lower.ascii}
+{
+  char.to.unicode #97 swap$ #122 swap$ is.int.in.range
+}
+
+FUNCTION {is.lower}
+{
+  duplicate$ is.lower.ascii
+    { pop$ #1 }
+    { latin.lower swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.printable.ascii}
+{
+  char.to.unicode #32 swap$ #126 swap$ is.int.in.range
+}
+
+FUNCTION {is.letter.ascii}
+{
+  duplicate$ is.upper.ascii swap$ is.lower.ascii or
+}
+
+FUNCTION {is.symbol.ascii}
+{
+  duplicate$ is.printable.ascii swap$ is.letter.ascii not and
+}
+
+FUNCTION {is.all.lower}
+{
+  #1 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str is.lower
+        'skip$
+        { pop$ pop$ #0 "" }
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.tex.str.in.title.case}
+{
+  duplicate$ "" =
+    { pop$ #0 }
+    {
+      split.first.tex.char.from.str purify$
+      duplicate$ "" =
+        { pop$ pop$ #0 }
+        {
+          split.first.char.from.str is.upper
+            {
+              duplicate$ is.all.lower
+                {
+                  empty$
+                    {
+                      duplicate$ "" =
+                        { pop$ #0 }
+                        'is.all.lower
+                      if$
+                    }
+                    'is.all.lower
+                  if$
+                }
+                { pop$ pop$ #0 }
+              if$
+            }
+            { pop$ pop$ #0}
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {is.in.inter.token.chars}
+{
+  duplicate$ #0 =
+    { pop$ " " = }
+    {
+      #1 =
+        { " " range.delimiters * swap$ is.char.in.str }
+        'is.letter.ascii
+      if$
+    }
+  if$
+}
+
+FUNCTION {skip.inter.token.chars.by}
+{
+  'b :=
+  't :=
+
+  "" t
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str
+      duplicate$ b is.in.inter.token.chars
+        { swap$ 't := * t }
+        { swap$ * 't := "" }
+      if$
+    }
+  while$
+
+  pop$ t
+}
+
+FUNCTION {skip.inter.token.chars}
+{
+  #0 skip.inter.token.chars.by
+}
+
+FUNCTION {skip.inter.token.command}
+{
+  duplicate$ "" =
+    { "" }
+    {
+      duplicate$ #1 #1 substring$ is.symbol.ascii
+        { split.first.char.from.str swap$ }
+        { #2 skip.inter.token.chars.by }
+     if$
+    }
+  if$
+}
+
+FUNCTION {is.special.char.command}
+{
+  #2 global.max$ substring$ skip.inter.token.command
+
+  empty$
+    'skip$
+    { "is.special.char.command: cmdstr has extra components!" warning$ }
+  if$
+
+  duplicate$ duplicate$ duplicate$ duplicate$ duplicate$ duplicate$
+  "oOlLij" swap$ is.char.in.str
+  swap$ "oe" = or
+  swap$ "OE" = or
+  swap$ "ae" = or
+  swap$ "AE" = or
+  swap$ "aa" = or
+  swap$ "AA" = or
+}
+
+FUNCTION {map.char}
+{
+  't :=
+  split.first.char.from.str
+  { swap$ duplicate$ "" = not }
+    {
+      swap$ t =
+        { pop$ "" t }
+        {
+          swap$ split.first.char.from.str pop$ swap$
+          split.first.char.from.str
+        }
+      if$
+    }
+  while$
+  pop$ t =
+    'get.first.char.from.str
+    { pop$ t }
+  if$
+}
+
+FUNCTION {to.lower}
+{
+  duplicate$ is.upper.ascii
+    { chr.to.int$ #32 + int.to.chr$ }
+    { latin.lower swap$ latin.upper swap$ map.char }
+  if$
+}
+
+FUNCTION {to.upper}
+{
+  duplicate$ is.lower.ascii
+    { chr.to.int$ #32 - int.to.chr$ }
+    { latin.upper swap$ latin.lower swap$ map.char }
+  if$
+}
+
+FUNCTION {all.to.lower}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.lower swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.lower}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+          duplicate$ is.special.char.command
+            'all.to.lower
+            'skip$
+          if$
+        }
+        'to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.lower}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+        {
+          split.first.char.from.str
+          duplicate$ #92 int.to.chr$ =
+            {
+              swap$ skip.inter.token.command 't := * t
+              swap$ command.to.lower
+            }
+            'to.lower
+          if$
+          swap$ 't := * t
+        }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {all.to.upper}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.upper swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.upper}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+           duplicate$ is.special.char.command
+             'all.to.upper
+             'skip$
+           if$
+        }
+        'to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.upper}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+      {
+        split.first.char.from.str
+        duplicate$ #92 int.to.chr$ =
+          {
+            swap$ skip.inter.token.command 't := * t
+            swap$ command.to.upper
+          }
+          'to.upper
+        if$
+        swap$ 't := * t
+      }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {lower.token.if.in.title.case}
+{
+  duplicate$ is.tex.str.in.title.case
+    { split.first.tex.char.from.str tex.to.lower swap$ * }
+    'skip$
+  if$
+}
+
+FUNCTION {self.tokens}
+{
+  #0 =
+    'default.self.tokens
+    'range.delimiters
+  if$
+}
+
+FUNCTION {tokenize.by}
+{
+  'b :=
+  's :=
+
+  s "" =
+    { "" "" }
+    {
+      s split.first.char.from.str
+      duplicate$ b self.tokens swap$ is.char.in.str
+        'swap$
+        {
+          duplicate$ #92 int.to.chr$ =
+            { swap$ skip.inter.token.command 's := * s }
+            {
+              pop$ pop$ "" s
+              { duplicate$ "" = not }
+                {
+                  split.first.char.from.str
+                  duplicate$ "\ " b self.tokens * swap$ is.char.in.str
+                    { pop$ pop$ "" }
+                    {
+                      duplicate$ "{" =
+                        { swap$ find.match.brace }
+                        'swap$
+                      if$
+                      's := * s
+                    }
+                  if$
+                }
+              while$
+              pop$ s
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tokenize}
+{
+  #0 tokenize.by
+}
+
+FUNCTION {smart.sentence.case}
+{
+  tokenize 's :=
+
+  { s "" = not }
+    {
+      s skip.inter.token.chars 's := * s
+      tokenize swap$
+      duplicate$ ":" =
+        {
+          swap$ 's := *
+          s skip.inter.token.chars 's := * s
+          tokenize swap$
+          lowercase.word.after.colon
+            {
+              duplicate$ "A" =
+                { pop$ "a" }
+                'lower.token.if.in.title.case
+              if$
+            }
+            'skip$
+          if$
+        }
+        'lower.token.if.in.title.case
+      if$
+      swap$ 's := *
+    }
+  while$
+}
+
+FUNCTION {smart.upper.case}
+{
+  s swap$ t swap$
+
+  "" swap$
+  { duplicate$ "" = not }
+    {
+      tokenize swap$
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        'command.to.upper
+        {
+          "" swap$
+          { duplicate$ "" = not }
+            {
+              split.first.tex.char.from.str tex.to.upper
+              swap$ 't := * t
+            }
+          while$
+          pop$
+        }
+      if$
+      swap$ 't := * t
+      skip.inter.token.chars 't := * t
+    }
+  while$
+  pop$
+
+  swap$ 't :=
+  swap$ 's :=
+}
+
 FUNCTION {field.or.null}
 { duplicate$ empty$
     { pop$ "" }
@@ -604,7 +1227,7 @@ FUNCTION {format.name}
       name.lang lang.en =
         { t #1 "{vv~}{ll}{ f{~}}" format.name$
           uppercase.name
-            { "u" change.case$ }
+            'smart.upper.case
             'skip$
           if$
           t #1 "{, jj}" format.name$ *
@@ -783,7 +1406,7 @@ FUNCTION {output.bibitem}
 
 FUNCTION {change.sentence.case}
 { entry.lang lang.en =
-    { "t" change.case$ }
+    'smart.sentence.case
     'skip$
   if$
 }
@@ -1393,32 +2016,27 @@ FUNCTION {format.urldate}
   if$
 }
 
-FUNCTION {hyphenate}
-{ 't :=
-  ""
-    { t empty$ not }
-    { t #1 #1 substring$ "-" =
-        { wave.dash.in.pages
-            { "～" * }
-            { "-" * }
-          if$
-            { t #1 #1 substring$ "-" = }
-            { t #2 global.max$ substring$ 't := }
-          while$
-        }
-        { t #1 #1 substring$ *
-          t #2 global.max$ substring$ 't :=
-        }
+FUNCTION {normalize.page.range}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    {
+      #1 skip.inter.token.chars.by 't :=
+      empty$
+        { "" }
+        'page.range.delimiter
       if$
+      * t
+      #1 tokenize.by 't :=
+      * t
     }
   while$
+  pop$
 }
 
 FUNCTION {format.pages}
-{ pages empty$
-    { "" }
-    { pages hyphenate }
-  if$
+{
+  pages normalize.page.range
 }
 
 FUNCTION {format.extracted.pages}
@@ -1426,8 +2044,8 @@ FUNCTION {format.extracted.pages}
     { "" }
     { pages
       only.start.page
-        'extract.before.dash
-        'hyphenate
+        { #1 tokenize.by pop$ }
+        'normalize.page.range
       if$
     }
   if$

--- a/variants/thu/thuthesis-bachelor.bst
+++ b/variants/thu/thuthesis-bachelor.bst
@@ -44,7 +44,6 @@ INTEGERS {
   show.missing.address.publisher
   space.before.pages
   only.start.page
-  wave.dash.in.pages
   show.urldate
   show.url
   show.doi
@@ -52,10 +51,12 @@ INTEGERS {
   show.note
   show.english.translation
   end.with.period
+  lowercase.word.after.colon
 }
 
 STRINGS {
   component.part.label
+  page.range.delimiter
 }
 
 FUNCTION {load.config}
@@ -84,7 +85,7 @@ FUNCTION {load.config}
   #0 'show.missing.address.publisher :=
   #1 'space.before.pages :=
   #0 'only.start.page :=
-  #0 'wave.dash.in.pages :=
+  "-" 'page.range.delimiter :=
   #1 'show.urldate :=
   #1 'show.url :=
   #1 'show.doi :=
@@ -92,6 +93,7 @@ FUNCTION {load.config}
   #0 'show.note :=
   #0 'show.english.translation :=
   #1 'end.with.period :=
+  #1 'lowercase.word.after.colon :=
 }
 
 ENTRY
@@ -233,6 +235,14 @@ FUNCTION {bbl.sine.loco.sine.nomine}
     { "[S.l.: s.n.]" }
   if$
 }
+
+FUNCTION {default.self.tokens} { ":,-'–—?.!" }
+
+FUNCTION {latin.upper} { "ÀÁÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİIĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ" }
+
+FUNCTION {latin.lower} { "àáãäåæçèéêëìíîïðñòóôõöøùúûüýþÿāăąćĉċčďđēĕėęěĝğġģĥħĩīĭįiıĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" }
+
+FUNCTION {range.delimiters} { "-–—～" }
 
 FUNCTION {not}
 {   { #0 }
@@ -439,6 +449,619 @@ FUNCTION {new.sentence.checkb}
   if$
 }
 
+INTEGERS { b }
+
+FUNCTION {is.int.in.range}
+{
+  'b :=
+  #1 +
+  b >
+    { #1 - b < }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {mult.power2}
+{
+  { duplicate$ #0 > }
+    {
+      swap$
+      duplicate$ +
+      swap$ #1 -
+    }
+  while$
+  pop$
+}
+
+FUNCTION {find.match.brace}
+{
+  's :=
+  't :=
+
+  #1
+  { duplicate$ #0 >
+    s empty$ not and }
+    {
+      s #1 #1 substring$ "{" =
+        { #1 + }
+        {
+          s #1 #1 substring$ "}" =
+            { #1 - }
+            'skip$
+          if$
+        }
+      if$
+      t s #1 #1 substring$ * 't :=
+      s #2 global.max$ substring$ 's :=
+    }
+  while$
+
+  duplicate$ #0 >
+    {
+      "Unbalanced brace(s): one or more closing braces are missing" warning$
+      { duplicate$ #0 > }
+        {
+          t "}" * 't :=
+          #1 -
+        }
+      while$
+    }
+    'skip$
+  if$
+  pop$
+
+  t
+  s
+}
+
+FUNCTION {split.first.char.from.str}
+{
+  duplicate$ "" =
+    {
+      "split.first.char.from.str: Trying to split an empty string!" warning$
+      ""
+    }
+    {
+      duplicate$ #1 #1 substring$ chr.to.int$ #128 <
+        {
+          duplicate$ #1 #1 substring$ swap$
+          #2 global.max$ substring$ swap$
+        }
+        {
+          duplicate$ #1 #1 substring$ chr.to.int$ #224 <
+            {
+              duplicate$ #1 #2 substring$ swap$
+              #3 global.max$ substring$ swap$
+            }
+            {
+              duplicate$ #1 #1 substring$ chr.to.int$ #240 <
+                {
+                  duplicate$ #1 #3 substring$ swap$
+                  #4 global.max$ substring$ swap$
+                }
+                {
+                  duplicate$ #1 #4 substring$ swap$
+                  #5 global.max$ substring$ swap$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {get.first.char.from.str}
+{
+  split.first.char.from.str swap$ pop$
+}
+
+FUNCTION {split.first.tex.char.from.str}
+{
+  duplicate$ #1 #1 substring$ "{" =
+    {
+      split.first.char.from.str swap$
+      find.match.brace swap$
+    }
+    'split.first.char.from.str
+  if$
+}
+
+FUNCTION {char.to.unicode}
+{
+  duplicate$ #4 #1 substring$ "" =
+    {
+      duplicate$ #3 #1 substring$ "" =
+        {
+          duplicate$ #2 #1 substring$ "" =
+            {
+              duplicate$ "" =
+                {
+                  "Empty string is not a char!" warning$
+                  pop$ #-1
+                }
+                { #1 #1 substring$ chr.to.int$ }
+              if$
+            }
+            {
+              duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+              #1 #1 substring$ chr.to.int$ #192 -
+              #6 mult.power2 +
+            }
+          if$
+        }
+        {
+          duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+          duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+          #1 #1 substring$ chr.to.int$ #224 -
+          #6 mult.power2 +
+          #6 mult.power2 +
+        }
+      if$
+    }
+    {
+      duplicate$ #4 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+      #1 #1 substring$ chr.to.int$ #240 -
+      #6 mult.power2 +
+      #6 mult.power2 +
+      #6 mult.power2 +
+    }
+  if$
+}
+
+FUNCTION {is.char.in.str}
+{
+  't :=
+
+  t "" =
+    { "is.char.in.str: Empty string is not a char!" warning$ }
+    'skip$
+  if$
+
+  #0 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str t =
+        { pop$ pop$ #1 "" }
+        'skip$
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.upper.ascii}
+{
+  char.to.unicode #65 swap$ #90 swap$ is.int.in.range
+}
+
+FUNCTION {is.upper}
+{
+  duplicate$ is.upper.ascii
+    { pop$ #1 }
+    { latin.upper swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.lower.ascii}
+{
+  char.to.unicode #97 swap$ #122 swap$ is.int.in.range
+}
+
+FUNCTION {is.lower}
+{
+  duplicate$ is.lower.ascii
+    { pop$ #1 }
+    { latin.lower swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.printable.ascii}
+{
+  char.to.unicode #32 swap$ #126 swap$ is.int.in.range
+}
+
+FUNCTION {is.letter.ascii}
+{
+  duplicate$ is.upper.ascii swap$ is.lower.ascii or
+}
+
+FUNCTION {is.symbol.ascii}
+{
+  duplicate$ is.printable.ascii swap$ is.letter.ascii not and
+}
+
+FUNCTION {is.all.lower}
+{
+  #1 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str is.lower
+        'skip$
+        { pop$ pop$ #0 "" }
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.tex.str.in.title.case}
+{
+  duplicate$ "" =
+    { pop$ #0 }
+    {
+      split.first.tex.char.from.str purify$
+      duplicate$ "" =
+        { pop$ pop$ #0 }
+        {
+          split.first.char.from.str is.upper
+            {
+              duplicate$ is.all.lower
+                {
+                  empty$
+                    {
+                      duplicate$ "" =
+                        { pop$ #0 }
+                        'is.all.lower
+                      if$
+                    }
+                    'is.all.lower
+                  if$
+                }
+                { pop$ pop$ #0 }
+              if$
+            }
+            { pop$ pop$ #0}
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {is.in.inter.token.chars}
+{
+  duplicate$ #0 =
+    { pop$ " " = }
+    {
+      #1 =
+        { " " range.delimiters * swap$ is.char.in.str }
+        'is.letter.ascii
+      if$
+    }
+  if$
+}
+
+FUNCTION {skip.inter.token.chars.by}
+{
+  'b :=
+  't :=
+
+  "" t
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str
+      duplicate$ b is.in.inter.token.chars
+        { swap$ 't := * t }
+        { swap$ * 't := "" }
+      if$
+    }
+  while$
+
+  pop$ t
+}
+
+FUNCTION {skip.inter.token.chars}
+{
+  #0 skip.inter.token.chars.by
+}
+
+FUNCTION {skip.inter.token.command}
+{
+  duplicate$ "" =
+    { "" }
+    {
+      duplicate$ #1 #1 substring$ is.symbol.ascii
+        { split.first.char.from.str swap$ }
+        { #2 skip.inter.token.chars.by }
+     if$
+    }
+  if$
+}
+
+FUNCTION {is.special.char.command}
+{
+  #2 global.max$ substring$ skip.inter.token.command
+
+  empty$
+    'skip$
+    { "is.special.char.command: cmdstr has extra components!" warning$ }
+  if$
+
+  duplicate$ duplicate$ duplicate$ duplicate$ duplicate$ duplicate$
+  "oOlLij" swap$ is.char.in.str
+  swap$ "oe" = or
+  swap$ "OE" = or
+  swap$ "ae" = or
+  swap$ "AE" = or
+  swap$ "aa" = or
+  swap$ "AA" = or
+}
+
+FUNCTION {map.char}
+{
+  't :=
+  split.first.char.from.str
+  { swap$ duplicate$ "" = not }
+    {
+      swap$ t =
+        { pop$ "" t }
+        {
+          swap$ split.first.char.from.str pop$ swap$
+          split.first.char.from.str
+        }
+      if$
+    }
+  while$
+  pop$ t =
+    'get.first.char.from.str
+    { pop$ t }
+  if$
+}
+
+FUNCTION {to.lower}
+{
+  duplicate$ is.upper.ascii
+    { chr.to.int$ #32 + int.to.chr$ }
+    { latin.lower swap$ latin.upper swap$ map.char }
+  if$
+}
+
+FUNCTION {to.upper}
+{
+  duplicate$ is.lower.ascii
+    { chr.to.int$ #32 - int.to.chr$ }
+    { latin.upper swap$ latin.lower swap$ map.char }
+  if$
+}
+
+FUNCTION {all.to.lower}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.lower swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.lower}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+          duplicate$ is.special.char.command
+            'all.to.lower
+            'skip$
+          if$
+        }
+        'to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.lower}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+        {
+          split.first.char.from.str
+          duplicate$ #92 int.to.chr$ =
+            {
+              swap$ skip.inter.token.command 't := * t
+              swap$ command.to.lower
+            }
+            'to.lower
+          if$
+          swap$ 't := * t
+        }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {all.to.upper}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.upper swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.upper}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+           duplicate$ is.special.char.command
+             'all.to.upper
+             'skip$
+           if$
+        }
+        'to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.upper}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+      {
+        split.first.char.from.str
+        duplicate$ #92 int.to.chr$ =
+          {
+            swap$ skip.inter.token.command 't := * t
+            swap$ command.to.upper
+          }
+          'to.upper
+        if$
+        swap$ 't := * t
+      }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {lower.token.if.in.title.case}
+{
+  duplicate$ is.tex.str.in.title.case
+    { split.first.tex.char.from.str tex.to.lower swap$ * }
+    'skip$
+  if$
+}
+
+FUNCTION {self.tokens}
+{
+  #0 =
+    'default.self.tokens
+    'range.delimiters
+  if$
+}
+
+FUNCTION {tokenize.by}
+{
+  'b :=
+  's :=
+
+  s "" =
+    { "" "" }
+    {
+      s split.first.char.from.str
+      duplicate$ b self.tokens swap$ is.char.in.str
+        'swap$
+        {
+          duplicate$ #92 int.to.chr$ =
+            { swap$ skip.inter.token.command 's := * s }
+            {
+              pop$ pop$ "" s
+              { duplicate$ "" = not }
+                {
+                  split.first.char.from.str
+                  duplicate$ "\ " b self.tokens * swap$ is.char.in.str
+                    { pop$ pop$ "" }
+                    {
+                      duplicate$ "{" =
+                        { swap$ find.match.brace }
+                        'swap$
+                      if$
+                      's := * s
+                    }
+                  if$
+                }
+              while$
+              pop$ s
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tokenize}
+{
+  #0 tokenize.by
+}
+
+FUNCTION {smart.sentence.case}
+{
+  tokenize 's :=
+
+  { s "" = not }
+    {
+      s skip.inter.token.chars 's := * s
+      tokenize swap$
+      duplicate$ ":" =
+        {
+          swap$ 's := *
+          s skip.inter.token.chars 's := * s
+          tokenize swap$
+          lowercase.word.after.colon
+            {
+              duplicate$ "A" =
+                { pop$ "a" }
+                'lower.token.if.in.title.case
+              if$
+            }
+            'skip$
+          if$
+        }
+        'lower.token.if.in.title.case
+      if$
+      swap$ 's := *
+    }
+  while$
+}
+
+FUNCTION {smart.upper.case}
+{
+  s swap$ t swap$
+
+  "" swap$
+  { duplicate$ "" = not }
+    {
+      tokenize swap$
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        'command.to.upper
+        {
+          "" swap$
+          { duplicate$ "" = not }
+            {
+              split.first.tex.char.from.str tex.to.upper
+              swap$ 't := * t
+            }
+          while$
+          pop$
+        }
+      if$
+      swap$ 't := * t
+      skip.inter.token.chars 't := * t
+    }
+  while$
+  pop$
+
+  swap$ 't :=
+  swap$ 's :=
+}
+
 FUNCTION {field.or.null}
 { duplicate$ empty$
     { pop$ "" }
@@ -594,7 +1217,7 @@ FUNCTION {format.name}
       name.lang lang.en =
         { t #1 "{vv~}{ll}{ f{~}}" format.name$
           uppercase.name
-            { "u" change.case$ }
+            'smart.upper.case
             'skip$
           if$
           t #1 "{, jj}" format.name$ *
@@ -773,7 +1396,7 @@ FUNCTION {output.bibitem}
 
 FUNCTION {change.sentence.case}
 { entry.lang lang.en =
-    { "t" change.case$ }
+    'smart.sentence.case
     'skip$
   if$
 }
@@ -1383,32 +2006,27 @@ FUNCTION {format.urldate}
   if$
 }
 
-FUNCTION {hyphenate}
-{ 't :=
-  ""
-    { t empty$ not }
-    { t #1 #1 substring$ "-" =
-        { wave.dash.in.pages
-            { "～" * }
-            { "-" * }
-          if$
-            { t #1 #1 substring$ "-" = }
-            { t #2 global.max$ substring$ 't := }
-          while$
-        }
-        { t #1 #1 substring$ *
-          t #2 global.max$ substring$ 't :=
-        }
+FUNCTION {normalize.page.range}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    {
+      #1 skip.inter.token.chars.by 't :=
+      empty$
+        { "" }
+        'page.range.delimiter
       if$
+      * t
+      #1 tokenize.by 't :=
+      * t
     }
   while$
+  pop$
 }
 
 FUNCTION {format.pages}
-{ pages empty$
-    { "" }
-    { pages hyphenate }
-  if$
+{
+  pages normalize.page.range
 }
 
 FUNCTION {format.extracted.pages}
@@ -1416,8 +2034,8 @@ FUNCTION {format.extracted.pages}
     { "" }
     { pages
       only.start.page
-        'extract.before.dash
-        'hyphenate
+        { #1 tokenize.by pop$ }
+        'normalize.page.range
       if$
     }
   if$

--- a/variants/thu/thuthesis-numeric.bst
+++ b/variants/thu/thuthesis-numeric.bst
@@ -44,7 +44,6 @@ INTEGERS {
   show.missing.address.publisher
   space.before.pages
   only.start.page
-  wave.dash.in.pages
   show.urldate
   show.url
   show.doi
@@ -52,10 +51,12 @@ INTEGERS {
   show.note
   show.english.translation
   end.with.period
+  lowercase.word.after.colon
 }
 
 STRINGS {
   component.part.label
+  page.range.delimiter
 }
 
 FUNCTION {load.config}
@@ -84,7 +85,7 @@ FUNCTION {load.config}
   #0 'show.missing.address.publisher :=
   #1 'space.before.pages :=
   #0 'only.start.page :=
-  #0 'wave.dash.in.pages :=
+  "-" 'page.range.delimiter :=
   #1 'show.urldate :=
   #1 'show.url :=
   #1 'show.doi :=
@@ -92,6 +93,7 @@ FUNCTION {load.config}
   #0 'show.note :=
   #0 'show.english.translation :=
   #1 'end.with.period :=
+  #1 'lowercase.word.after.colon :=
 }
 
 ENTRY
@@ -233,6 +235,14 @@ FUNCTION {bbl.sine.loco.sine.nomine}
     { "[S.l.: s.n.]" }
   if$
 }
+
+FUNCTION {default.self.tokens} { ":,-'–—?.!" }
+
+FUNCTION {latin.upper} { "ÀÁÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİIĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ" }
+
+FUNCTION {latin.lower} { "àáãäåæçèéêëìíîïðñòóôõöøùúûüýþÿāăąćĉċčďđēĕėęěĝğġģĥħĩīĭįiıĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" }
+
+FUNCTION {range.delimiters} { "-–—～" }
 
 FUNCTION {not}
 {   { #0 }
@@ -439,6 +449,619 @@ FUNCTION {new.sentence.checkb}
   if$
 }
 
+INTEGERS { b }
+
+FUNCTION {is.int.in.range}
+{
+  'b :=
+  #1 +
+  b >
+    { #1 - b < }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {mult.power2}
+{
+  { duplicate$ #0 > }
+    {
+      swap$
+      duplicate$ +
+      swap$ #1 -
+    }
+  while$
+  pop$
+}
+
+FUNCTION {find.match.brace}
+{
+  's :=
+  't :=
+
+  #1
+  { duplicate$ #0 >
+    s empty$ not and }
+    {
+      s #1 #1 substring$ "{" =
+        { #1 + }
+        {
+          s #1 #1 substring$ "}" =
+            { #1 - }
+            'skip$
+          if$
+        }
+      if$
+      t s #1 #1 substring$ * 't :=
+      s #2 global.max$ substring$ 's :=
+    }
+  while$
+
+  duplicate$ #0 >
+    {
+      "Unbalanced brace(s): one or more closing braces are missing" warning$
+      { duplicate$ #0 > }
+        {
+          t "}" * 't :=
+          #1 -
+        }
+      while$
+    }
+    'skip$
+  if$
+  pop$
+
+  t
+  s
+}
+
+FUNCTION {split.first.char.from.str}
+{
+  duplicate$ "" =
+    {
+      "split.first.char.from.str: Trying to split an empty string!" warning$
+      ""
+    }
+    {
+      duplicate$ #1 #1 substring$ chr.to.int$ #128 <
+        {
+          duplicate$ #1 #1 substring$ swap$
+          #2 global.max$ substring$ swap$
+        }
+        {
+          duplicate$ #1 #1 substring$ chr.to.int$ #224 <
+            {
+              duplicate$ #1 #2 substring$ swap$
+              #3 global.max$ substring$ swap$
+            }
+            {
+              duplicate$ #1 #1 substring$ chr.to.int$ #240 <
+                {
+                  duplicate$ #1 #3 substring$ swap$
+                  #4 global.max$ substring$ swap$
+                }
+                {
+                  duplicate$ #1 #4 substring$ swap$
+                  #5 global.max$ substring$ swap$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {get.first.char.from.str}
+{
+  split.first.char.from.str swap$ pop$
+}
+
+FUNCTION {split.first.tex.char.from.str}
+{
+  duplicate$ #1 #1 substring$ "{" =
+    {
+      split.first.char.from.str swap$
+      find.match.brace swap$
+    }
+    'split.first.char.from.str
+  if$
+}
+
+FUNCTION {char.to.unicode}
+{
+  duplicate$ #4 #1 substring$ "" =
+    {
+      duplicate$ #3 #1 substring$ "" =
+        {
+          duplicate$ #2 #1 substring$ "" =
+            {
+              duplicate$ "" =
+                {
+                  "Empty string is not a char!" warning$
+                  pop$ #-1
+                }
+                { #1 #1 substring$ chr.to.int$ }
+              if$
+            }
+            {
+              duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+              #1 #1 substring$ chr.to.int$ #192 -
+              #6 mult.power2 +
+            }
+          if$
+        }
+        {
+          duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+          duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+          #1 #1 substring$ chr.to.int$ #224 -
+          #6 mult.power2 +
+          #6 mult.power2 +
+        }
+      if$
+    }
+    {
+      duplicate$ #4 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+      #1 #1 substring$ chr.to.int$ #240 -
+      #6 mult.power2 +
+      #6 mult.power2 +
+      #6 mult.power2 +
+    }
+  if$
+}
+
+FUNCTION {is.char.in.str}
+{
+  't :=
+
+  t "" =
+    { "is.char.in.str: Empty string is not a char!" warning$ }
+    'skip$
+  if$
+
+  #0 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str t =
+        { pop$ pop$ #1 "" }
+        'skip$
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.upper.ascii}
+{
+  char.to.unicode #65 swap$ #90 swap$ is.int.in.range
+}
+
+FUNCTION {is.upper}
+{
+  duplicate$ is.upper.ascii
+    { pop$ #1 }
+    { latin.upper swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.lower.ascii}
+{
+  char.to.unicode #97 swap$ #122 swap$ is.int.in.range
+}
+
+FUNCTION {is.lower}
+{
+  duplicate$ is.lower.ascii
+    { pop$ #1 }
+    { latin.lower swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.printable.ascii}
+{
+  char.to.unicode #32 swap$ #126 swap$ is.int.in.range
+}
+
+FUNCTION {is.letter.ascii}
+{
+  duplicate$ is.upper.ascii swap$ is.lower.ascii or
+}
+
+FUNCTION {is.symbol.ascii}
+{
+  duplicate$ is.printable.ascii swap$ is.letter.ascii not and
+}
+
+FUNCTION {is.all.lower}
+{
+  #1 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str is.lower
+        'skip$
+        { pop$ pop$ #0 "" }
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.tex.str.in.title.case}
+{
+  duplicate$ "" =
+    { pop$ #0 }
+    {
+      split.first.tex.char.from.str purify$
+      duplicate$ "" =
+        { pop$ pop$ #0 }
+        {
+          split.first.char.from.str is.upper
+            {
+              duplicate$ is.all.lower
+                {
+                  empty$
+                    {
+                      duplicate$ "" =
+                        { pop$ #0 }
+                        'is.all.lower
+                      if$
+                    }
+                    'is.all.lower
+                  if$
+                }
+                { pop$ pop$ #0 }
+              if$
+            }
+            { pop$ pop$ #0}
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {is.in.inter.token.chars}
+{
+  duplicate$ #0 =
+    { pop$ " " = }
+    {
+      #1 =
+        { " " range.delimiters * swap$ is.char.in.str }
+        'is.letter.ascii
+      if$
+    }
+  if$
+}
+
+FUNCTION {skip.inter.token.chars.by}
+{
+  'b :=
+  't :=
+
+  "" t
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str
+      duplicate$ b is.in.inter.token.chars
+        { swap$ 't := * t }
+        { swap$ * 't := "" }
+      if$
+    }
+  while$
+
+  pop$ t
+}
+
+FUNCTION {skip.inter.token.chars}
+{
+  #0 skip.inter.token.chars.by
+}
+
+FUNCTION {skip.inter.token.command}
+{
+  duplicate$ "" =
+    { "" }
+    {
+      duplicate$ #1 #1 substring$ is.symbol.ascii
+        { split.first.char.from.str swap$ }
+        { #2 skip.inter.token.chars.by }
+     if$
+    }
+  if$
+}
+
+FUNCTION {is.special.char.command}
+{
+  #2 global.max$ substring$ skip.inter.token.command
+
+  empty$
+    'skip$
+    { "is.special.char.command: cmdstr has extra components!" warning$ }
+  if$
+
+  duplicate$ duplicate$ duplicate$ duplicate$ duplicate$ duplicate$
+  "oOlLij" swap$ is.char.in.str
+  swap$ "oe" = or
+  swap$ "OE" = or
+  swap$ "ae" = or
+  swap$ "AE" = or
+  swap$ "aa" = or
+  swap$ "AA" = or
+}
+
+FUNCTION {map.char}
+{
+  't :=
+  split.first.char.from.str
+  { swap$ duplicate$ "" = not }
+    {
+      swap$ t =
+        { pop$ "" t }
+        {
+          swap$ split.first.char.from.str pop$ swap$
+          split.first.char.from.str
+        }
+      if$
+    }
+  while$
+  pop$ t =
+    'get.first.char.from.str
+    { pop$ t }
+  if$
+}
+
+FUNCTION {to.lower}
+{
+  duplicate$ is.upper.ascii
+    { chr.to.int$ #32 + int.to.chr$ }
+    { latin.lower swap$ latin.upper swap$ map.char }
+  if$
+}
+
+FUNCTION {to.upper}
+{
+  duplicate$ is.lower.ascii
+    { chr.to.int$ #32 - int.to.chr$ }
+    { latin.upper swap$ latin.lower swap$ map.char }
+  if$
+}
+
+FUNCTION {all.to.lower}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.lower swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.lower}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+          duplicate$ is.special.char.command
+            'all.to.lower
+            'skip$
+          if$
+        }
+        'to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.lower}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+        {
+          split.first.char.from.str
+          duplicate$ #92 int.to.chr$ =
+            {
+              swap$ skip.inter.token.command 't := * t
+              swap$ command.to.lower
+            }
+            'to.lower
+          if$
+          swap$ 't := * t
+        }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {all.to.upper}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.upper swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.upper}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+           duplicate$ is.special.char.command
+             'all.to.upper
+             'skip$
+           if$
+        }
+        'to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.upper}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+      {
+        split.first.char.from.str
+        duplicate$ #92 int.to.chr$ =
+          {
+            swap$ skip.inter.token.command 't := * t
+            swap$ command.to.upper
+          }
+          'to.upper
+        if$
+        swap$ 't := * t
+      }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {lower.token.if.in.title.case}
+{
+  duplicate$ is.tex.str.in.title.case
+    { split.first.tex.char.from.str tex.to.lower swap$ * }
+    'skip$
+  if$
+}
+
+FUNCTION {self.tokens}
+{
+  #0 =
+    'default.self.tokens
+    'range.delimiters
+  if$
+}
+
+FUNCTION {tokenize.by}
+{
+  'b :=
+  's :=
+
+  s "" =
+    { "" "" }
+    {
+      s split.first.char.from.str
+      duplicate$ b self.tokens swap$ is.char.in.str
+        'swap$
+        {
+          duplicate$ #92 int.to.chr$ =
+            { swap$ skip.inter.token.command 's := * s }
+            {
+              pop$ pop$ "" s
+              { duplicate$ "" = not }
+                {
+                  split.first.char.from.str
+                  duplicate$ "\ " b self.tokens * swap$ is.char.in.str
+                    { pop$ pop$ "" }
+                    {
+                      duplicate$ "{" =
+                        { swap$ find.match.brace }
+                        'swap$
+                      if$
+                      's := * s
+                    }
+                  if$
+                }
+              while$
+              pop$ s
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tokenize}
+{
+  #0 tokenize.by
+}
+
+FUNCTION {smart.sentence.case}
+{
+  tokenize 's :=
+
+  { s "" = not }
+    {
+      s skip.inter.token.chars 's := * s
+      tokenize swap$
+      duplicate$ ":" =
+        {
+          swap$ 's := *
+          s skip.inter.token.chars 's := * s
+          tokenize swap$
+          lowercase.word.after.colon
+            {
+              duplicate$ "A" =
+                { pop$ "a" }
+                'lower.token.if.in.title.case
+              if$
+            }
+            'skip$
+          if$
+        }
+        'lower.token.if.in.title.case
+      if$
+      swap$ 's := *
+    }
+  while$
+}
+
+FUNCTION {smart.upper.case}
+{
+  s swap$ t swap$
+
+  "" swap$
+  { duplicate$ "" = not }
+    {
+      tokenize swap$
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        'command.to.upper
+        {
+          "" swap$
+          { duplicate$ "" = not }
+            {
+              split.first.tex.char.from.str tex.to.upper
+              swap$ 't := * t
+            }
+          while$
+          pop$
+        }
+      if$
+      swap$ 't := * t
+      skip.inter.token.chars 't := * t
+    }
+  while$
+  pop$
+
+  swap$ 't :=
+  swap$ 's :=
+}
+
 FUNCTION {field.or.null}
 { duplicate$ empty$
     { pop$ "" }
@@ -594,7 +1217,7 @@ FUNCTION {format.name}
       name.lang lang.en =
         { t #1 "{vv~}{ll}{ f{~}}" format.name$
           uppercase.name
-            { "u" change.case$ }
+            'smart.upper.case
             'skip$
           if$
           t #1 "{, jj}" format.name$ *
@@ -773,7 +1396,7 @@ FUNCTION {output.bibitem}
 
 FUNCTION {change.sentence.case}
 { entry.lang lang.en =
-    { "t" change.case$ }
+    'smart.sentence.case
     'skip$
   if$
 }
@@ -1383,32 +2006,27 @@ FUNCTION {format.urldate}
   if$
 }
 
-FUNCTION {hyphenate}
-{ 't :=
-  ""
-    { t empty$ not }
-    { t #1 #1 substring$ "-" =
-        { wave.dash.in.pages
-            { "～" * }
-            { "-" * }
-          if$
-            { t #1 #1 substring$ "-" = }
-            { t #2 global.max$ substring$ 't := }
-          while$
-        }
-        { t #1 #1 substring$ *
-          t #2 global.max$ substring$ 't :=
-        }
+FUNCTION {normalize.page.range}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    {
+      #1 skip.inter.token.chars.by 't :=
+      empty$
+        { "" }
+        'page.range.delimiter
       if$
+      * t
+      #1 tokenize.by 't :=
+      * t
     }
   while$
+  pop$
 }
 
 FUNCTION {format.pages}
-{ pages empty$
-    { "" }
-    { pages hyphenate }
-  if$
+{
+  pages normalize.page.range
 }
 
 FUNCTION {format.extracted.pages}
@@ -1416,8 +2034,8 @@ FUNCTION {format.extracted.pages}
     { "" }
     { pages
       only.start.page
-        'extract.before.dash
-        'hyphenate
+        { #1 tokenize.by pop$ }
+        'normalize.page.range
       if$
     }
   if$

--- a/variants/ucas/ucasthesis-author-year.bst
+++ b/variants/ucas/ucasthesis-author-year.bst
@@ -44,7 +44,6 @@ INTEGERS {
   show.missing.address.publisher
   space.before.pages
   only.start.page
-  wave.dash.in.pages
   show.urldate
   show.url
   show.doi
@@ -52,6 +51,7 @@ INTEGERS {
   show.note
   show.english.translation
   end.with.period
+  lowercase.word.after.colon
   lang.zh.order
   lang.ja.order
   lang.en.order
@@ -61,6 +61,7 @@ INTEGERS {
 
 STRINGS {
   component.part.label
+  page.range.delimiter
 }
 
 FUNCTION {load.config}
@@ -89,7 +90,7 @@ FUNCTION {load.config}
   #0 'show.missing.address.publisher :=
   #1 'space.before.pages :=
   #0 'only.start.page :=
-  #0 'wave.dash.in.pages :=
+  "-" 'page.range.delimiter :=
   #1 'show.urldate :=
   #1 'show.url :=
   #1 'show.doi :=
@@ -97,6 +98,7 @@ FUNCTION {load.config}
   #0 'show.note :=
   #0 'show.english.translation :=
   #1 'end.with.period :=
+  #1 'lowercase.word.after.colon :=
   #1 'lang.zh.order :=
   #2 'lang.ja.order :=
   #3 'lang.en.order :=
@@ -243,6 +245,14 @@ FUNCTION {bbl.sine.loco.sine.nomine}
     { "[S.l.: s.n.]" }
   if$
 }
+
+FUNCTION {default.self.tokens} { ":,-'–—?.!" }
+
+FUNCTION {latin.upper} { "ÀÁÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİIĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ" }
+
+FUNCTION {latin.lower} { "àáãäåæçèéêëìíîïðñòóôõöøùúûüýþÿāăąćĉċčďđēĕėęěĝğġģĥħĩīĭįiıĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" }
+
+FUNCTION {range.delimiters} { "-–—～" }
 
 FUNCTION {not}
 {   { #0 }
@@ -449,6 +459,619 @@ FUNCTION {new.sentence.checkb}
   if$
 }
 
+INTEGERS { b }
+
+FUNCTION {is.int.in.range}
+{
+  'b :=
+  #1 +
+  b >
+    { #1 - b < }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {mult.power2}
+{
+  { duplicate$ #0 > }
+    {
+      swap$
+      duplicate$ +
+      swap$ #1 -
+    }
+  while$
+  pop$
+}
+
+FUNCTION {find.match.brace}
+{
+  's :=
+  't :=
+
+  #1
+  { duplicate$ #0 >
+    s empty$ not and }
+    {
+      s #1 #1 substring$ "{" =
+        { #1 + }
+        {
+          s #1 #1 substring$ "}" =
+            { #1 - }
+            'skip$
+          if$
+        }
+      if$
+      t s #1 #1 substring$ * 't :=
+      s #2 global.max$ substring$ 's :=
+    }
+  while$
+
+  duplicate$ #0 >
+    {
+      "Unbalanced brace(s): one or more closing braces are missing" warning$
+      { duplicate$ #0 > }
+        {
+          t "}" * 't :=
+          #1 -
+        }
+      while$
+    }
+    'skip$
+  if$
+  pop$
+
+  t
+  s
+}
+
+FUNCTION {split.first.char.from.str}
+{
+  duplicate$ "" =
+    {
+      "split.first.char.from.str: Trying to split an empty string!" warning$
+      ""
+    }
+    {
+      duplicate$ #1 #1 substring$ chr.to.int$ #128 <
+        {
+          duplicate$ #1 #1 substring$ swap$
+          #2 global.max$ substring$ swap$
+        }
+        {
+          duplicate$ #1 #1 substring$ chr.to.int$ #224 <
+            {
+              duplicate$ #1 #2 substring$ swap$
+              #3 global.max$ substring$ swap$
+            }
+            {
+              duplicate$ #1 #1 substring$ chr.to.int$ #240 <
+                {
+                  duplicate$ #1 #3 substring$ swap$
+                  #4 global.max$ substring$ swap$
+                }
+                {
+                  duplicate$ #1 #4 substring$ swap$
+                  #5 global.max$ substring$ swap$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {get.first.char.from.str}
+{
+  split.first.char.from.str swap$ pop$
+}
+
+FUNCTION {split.first.tex.char.from.str}
+{
+  duplicate$ #1 #1 substring$ "{" =
+    {
+      split.first.char.from.str swap$
+      find.match.brace swap$
+    }
+    'split.first.char.from.str
+  if$
+}
+
+FUNCTION {char.to.unicode}
+{
+  duplicate$ #4 #1 substring$ "" =
+    {
+      duplicate$ #3 #1 substring$ "" =
+        {
+          duplicate$ #2 #1 substring$ "" =
+            {
+              duplicate$ "" =
+                {
+                  "Empty string is not a char!" warning$
+                  pop$ #-1
+                }
+                { #1 #1 substring$ chr.to.int$ }
+              if$
+            }
+            {
+              duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+              #1 #1 substring$ chr.to.int$ #192 -
+              #6 mult.power2 +
+            }
+          if$
+        }
+        {
+          duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+          duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+          #1 #1 substring$ chr.to.int$ #224 -
+          #6 mult.power2 +
+          #6 mult.power2 +
+        }
+      if$
+    }
+    {
+      duplicate$ #4 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+      #1 #1 substring$ chr.to.int$ #240 -
+      #6 mult.power2 +
+      #6 mult.power2 +
+      #6 mult.power2 +
+    }
+  if$
+}
+
+FUNCTION {is.char.in.str}
+{
+  't :=
+
+  t "" =
+    { "is.char.in.str: Empty string is not a char!" warning$ }
+    'skip$
+  if$
+
+  #0 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str t =
+        { pop$ pop$ #1 "" }
+        'skip$
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.upper.ascii}
+{
+  char.to.unicode #65 swap$ #90 swap$ is.int.in.range
+}
+
+FUNCTION {is.upper}
+{
+  duplicate$ is.upper.ascii
+    { pop$ #1 }
+    { latin.upper swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.lower.ascii}
+{
+  char.to.unicode #97 swap$ #122 swap$ is.int.in.range
+}
+
+FUNCTION {is.lower}
+{
+  duplicate$ is.lower.ascii
+    { pop$ #1 }
+    { latin.lower swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.printable.ascii}
+{
+  char.to.unicode #32 swap$ #126 swap$ is.int.in.range
+}
+
+FUNCTION {is.letter.ascii}
+{
+  duplicate$ is.upper.ascii swap$ is.lower.ascii or
+}
+
+FUNCTION {is.symbol.ascii}
+{
+  duplicate$ is.printable.ascii swap$ is.letter.ascii not and
+}
+
+FUNCTION {is.all.lower}
+{
+  #1 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str is.lower
+        'skip$
+        { pop$ pop$ #0 "" }
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.tex.str.in.title.case}
+{
+  duplicate$ "" =
+    { pop$ #0 }
+    {
+      split.first.tex.char.from.str purify$
+      duplicate$ "" =
+        { pop$ pop$ #0 }
+        {
+          split.first.char.from.str is.upper
+            {
+              duplicate$ is.all.lower
+                {
+                  empty$
+                    {
+                      duplicate$ "" =
+                        { pop$ #0 }
+                        'is.all.lower
+                      if$
+                    }
+                    'is.all.lower
+                  if$
+                }
+                { pop$ pop$ #0 }
+              if$
+            }
+            { pop$ pop$ #0}
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {is.in.inter.token.chars}
+{
+  duplicate$ #0 =
+    { pop$ " " = }
+    {
+      #1 =
+        { " " range.delimiters * swap$ is.char.in.str }
+        'is.letter.ascii
+      if$
+    }
+  if$
+}
+
+FUNCTION {skip.inter.token.chars.by}
+{
+  'b :=
+  't :=
+
+  "" t
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str
+      duplicate$ b is.in.inter.token.chars
+        { swap$ 't := * t }
+        { swap$ * 't := "" }
+      if$
+    }
+  while$
+
+  pop$ t
+}
+
+FUNCTION {skip.inter.token.chars}
+{
+  #0 skip.inter.token.chars.by
+}
+
+FUNCTION {skip.inter.token.command}
+{
+  duplicate$ "" =
+    { "" }
+    {
+      duplicate$ #1 #1 substring$ is.symbol.ascii
+        { split.first.char.from.str swap$ }
+        { #2 skip.inter.token.chars.by }
+     if$
+    }
+  if$
+}
+
+FUNCTION {is.special.char.command}
+{
+  #2 global.max$ substring$ skip.inter.token.command
+
+  empty$
+    'skip$
+    { "is.special.char.command: cmdstr has extra components!" warning$ }
+  if$
+
+  duplicate$ duplicate$ duplicate$ duplicate$ duplicate$ duplicate$
+  "oOlLij" swap$ is.char.in.str
+  swap$ "oe" = or
+  swap$ "OE" = or
+  swap$ "ae" = or
+  swap$ "AE" = or
+  swap$ "aa" = or
+  swap$ "AA" = or
+}
+
+FUNCTION {map.char}
+{
+  't :=
+  split.first.char.from.str
+  { swap$ duplicate$ "" = not }
+    {
+      swap$ t =
+        { pop$ "" t }
+        {
+          swap$ split.first.char.from.str pop$ swap$
+          split.first.char.from.str
+        }
+      if$
+    }
+  while$
+  pop$ t =
+    'get.first.char.from.str
+    { pop$ t }
+  if$
+}
+
+FUNCTION {to.lower}
+{
+  duplicate$ is.upper.ascii
+    { chr.to.int$ #32 + int.to.chr$ }
+    { latin.lower swap$ latin.upper swap$ map.char }
+  if$
+}
+
+FUNCTION {to.upper}
+{
+  duplicate$ is.lower.ascii
+    { chr.to.int$ #32 - int.to.chr$ }
+    { latin.upper swap$ latin.lower swap$ map.char }
+  if$
+}
+
+FUNCTION {all.to.lower}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.lower swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.lower}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+          duplicate$ is.special.char.command
+            'all.to.lower
+            'skip$
+          if$
+        }
+        'to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.lower}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+        {
+          split.first.char.from.str
+          duplicate$ #92 int.to.chr$ =
+            {
+              swap$ skip.inter.token.command 't := * t
+              swap$ command.to.lower
+            }
+            'to.lower
+          if$
+          swap$ 't := * t
+        }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {all.to.upper}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.upper swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.upper}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+           duplicate$ is.special.char.command
+             'all.to.upper
+             'skip$
+           if$
+        }
+        'to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.upper}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+      {
+        split.first.char.from.str
+        duplicate$ #92 int.to.chr$ =
+          {
+            swap$ skip.inter.token.command 't := * t
+            swap$ command.to.upper
+          }
+          'to.upper
+        if$
+        swap$ 't := * t
+      }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {lower.token.if.in.title.case}
+{
+  duplicate$ is.tex.str.in.title.case
+    { split.first.tex.char.from.str tex.to.lower swap$ * }
+    'skip$
+  if$
+}
+
+FUNCTION {self.tokens}
+{
+  #0 =
+    'default.self.tokens
+    'range.delimiters
+  if$
+}
+
+FUNCTION {tokenize.by}
+{
+  'b :=
+  's :=
+
+  s "" =
+    { "" "" }
+    {
+      s split.first.char.from.str
+      duplicate$ b self.tokens swap$ is.char.in.str
+        'swap$
+        {
+          duplicate$ #92 int.to.chr$ =
+            { swap$ skip.inter.token.command 's := * s }
+            {
+              pop$ pop$ "" s
+              { duplicate$ "" = not }
+                {
+                  split.first.char.from.str
+                  duplicate$ "\ " b self.tokens * swap$ is.char.in.str
+                    { pop$ pop$ "" }
+                    {
+                      duplicate$ "{" =
+                        { swap$ find.match.brace }
+                        'swap$
+                      if$
+                      's := * s
+                    }
+                  if$
+                }
+              while$
+              pop$ s
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tokenize}
+{
+  #0 tokenize.by
+}
+
+FUNCTION {smart.sentence.case}
+{
+  tokenize 's :=
+
+  { s "" = not }
+    {
+      s skip.inter.token.chars 's := * s
+      tokenize swap$
+      duplicate$ ":" =
+        {
+          swap$ 's := *
+          s skip.inter.token.chars 's := * s
+          tokenize swap$
+          lowercase.word.after.colon
+            {
+              duplicate$ "A" =
+                { pop$ "a" }
+                'lower.token.if.in.title.case
+              if$
+            }
+            'skip$
+          if$
+        }
+        'lower.token.if.in.title.case
+      if$
+      swap$ 's := *
+    }
+  while$
+}
+
+FUNCTION {smart.upper.case}
+{
+  s swap$ t swap$
+
+  "" swap$
+  { duplicate$ "" = not }
+    {
+      tokenize swap$
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        'command.to.upper
+        {
+          "" swap$
+          { duplicate$ "" = not }
+            {
+              split.first.tex.char.from.str tex.to.upper
+              swap$ 't := * t
+            }
+          while$
+          pop$
+        }
+      if$
+      swap$ 't := * t
+      skip.inter.token.chars 't := * t
+    }
+  while$
+  pop$
+
+  swap$ 't :=
+  swap$ 's :=
+}
+
 FUNCTION {field.or.null}
 { duplicate$ empty$
     { pop$ "" }
@@ -604,7 +1227,7 @@ FUNCTION {format.name}
       name.lang lang.en =
         { t #1 "{vv~}{ll}{ f{~}}" format.name$
           uppercase.name
-            { "u" change.case$ }
+            'smart.upper.case
             'skip$
           if$
           t #1 "{, jj}" format.name$ *
@@ -783,7 +1406,7 @@ FUNCTION {output.bibitem}
 
 FUNCTION {change.sentence.case}
 { entry.lang lang.en =
-    { "t" change.case$ }
+    'smart.sentence.case
     'skip$
   if$
 }
@@ -1393,32 +2016,27 @@ FUNCTION {format.urldate}
   if$
 }
 
-FUNCTION {hyphenate}
-{ 't :=
-  ""
-    { t empty$ not }
-    { t #1 #1 substring$ "-" =
-        { wave.dash.in.pages
-            { "～" * }
-            { "-" * }
-          if$
-            { t #1 #1 substring$ "-" = }
-            { t #2 global.max$ substring$ 't := }
-          while$
-        }
-        { t #1 #1 substring$ *
-          t #2 global.max$ substring$ 't :=
-        }
+FUNCTION {normalize.page.range}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    {
+      #1 skip.inter.token.chars.by 't :=
+      empty$
+        { "" }
+        'page.range.delimiter
       if$
+      * t
+      #1 tokenize.by 't :=
+      * t
     }
   while$
+  pop$
 }
 
 FUNCTION {format.pages}
-{ pages empty$
-    { "" }
-    { pages hyphenate }
-  if$
+{
+  pages normalize.page.range
 }
 
 FUNCTION {format.extracted.pages}
@@ -1426,8 +2044,8 @@ FUNCTION {format.extracted.pages}
     { "" }
     { pages
       only.start.page
-        'extract.before.dash
-        'hyphenate
+        { #1 tokenize.by pop$ }
+        'normalize.page.range
       if$
     }
   if$

--- a/variants/ucas/ucasthesis-numerical.bst
+++ b/variants/ucas/ucasthesis-numerical.bst
@@ -44,7 +44,6 @@ INTEGERS {
   show.missing.address.publisher
   space.before.pages
   only.start.page
-  wave.dash.in.pages
   show.urldate
   show.url
   show.doi
@@ -52,10 +51,12 @@ INTEGERS {
   show.note
   show.english.translation
   end.with.period
+  lowercase.word.after.colon
 }
 
 STRINGS {
   component.part.label
+  page.range.delimiter
 }
 
 FUNCTION {load.config}
@@ -84,7 +85,7 @@ FUNCTION {load.config}
   #0 'show.missing.address.publisher :=
   #1 'space.before.pages :=
   #0 'only.start.page :=
-  #0 'wave.dash.in.pages :=
+  "-" 'page.range.delimiter :=
   #1 'show.urldate :=
   #1 'show.url :=
   #1 'show.doi :=
@@ -92,6 +93,7 @@ FUNCTION {load.config}
   #0 'show.note :=
   #0 'show.english.translation :=
   #1 'end.with.period :=
+  #1 'lowercase.word.after.colon :=
 }
 
 ENTRY
@@ -233,6 +235,14 @@ FUNCTION {bbl.sine.loco.sine.nomine}
     { "[S.l.: s.n.]" }
   if$
 }
+
+FUNCTION {default.self.tokens} { ":,-'–—?.!" }
+
+FUNCTION {latin.upper} { "ÀÁÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİIĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ" }
+
+FUNCTION {latin.lower} { "àáãäåæçèéêëìíîïðñòóôõöøùúûüýþÿāăąćĉċčďđēĕėęěĝğġģĥħĩīĭįiıĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" }
+
+FUNCTION {range.delimiters} { "-–—～" }
 
 FUNCTION {not}
 {   { #0 }
@@ -439,6 +449,619 @@ FUNCTION {new.sentence.checkb}
   if$
 }
 
+INTEGERS { b }
+
+FUNCTION {is.int.in.range}
+{
+  'b :=
+  #1 +
+  b >
+    { #1 - b < }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {mult.power2}
+{
+  { duplicate$ #0 > }
+    {
+      swap$
+      duplicate$ +
+      swap$ #1 -
+    }
+  while$
+  pop$
+}
+
+FUNCTION {find.match.brace}
+{
+  's :=
+  't :=
+
+  #1
+  { duplicate$ #0 >
+    s empty$ not and }
+    {
+      s #1 #1 substring$ "{" =
+        { #1 + }
+        {
+          s #1 #1 substring$ "}" =
+            { #1 - }
+            'skip$
+          if$
+        }
+      if$
+      t s #1 #1 substring$ * 't :=
+      s #2 global.max$ substring$ 's :=
+    }
+  while$
+
+  duplicate$ #0 >
+    {
+      "Unbalanced brace(s): one or more closing braces are missing" warning$
+      { duplicate$ #0 > }
+        {
+          t "}" * 't :=
+          #1 -
+        }
+      while$
+    }
+    'skip$
+  if$
+  pop$
+
+  t
+  s
+}
+
+FUNCTION {split.first.char.from.str}
+{
+  duplicate$ "" =
+    {
+      "split.first.char.from.str: Trying to split an empty string!" warning$
+      ""
+    }
+    {
+      duplicate$ #1 #1 substring$ chr.to.int$ #128 <
+        {
+          duplicate$ #1 #1 substring$ swap$
+          #2 global.max$ substring$ swap$
+        }
+        {
+          duplicate$ #1 #1 substring$ chr.to.int$ #224 <
+            {
+              duplicate$ #1 #2 substring$ swap$
+              #3 global.max$ substring$ swap$
+            }
+            {
+              duplicate$ #1 #1 substring$ chr.to.int$ #240 <
+                {
+                  duplicate$ #1 #3 substring$ swap$
+                  #4 global.max$ substring$ swap$
+                }
+                {
+                  duplicate$ #1 #4 substring$ swap$
+                  #5 global.max$ substring$ swap$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {get.first.char.from.str}
+{
+  split.first.char.from.str swap$ pop$
+}
+
+FUNCTION {split.first.tex.char.from.str}
+{
+  duplicate$ #1 #1 substring$ "{" =
+    {
+      split.first.char.from.str swap$
+      find.match.brace swap$
+    }
+    'split.first.char.from.str
+  if$
+}
+
+FUNCTION {char.to.unicode}
+{
+  duplicate$ #4 #1 substring$ "" =
+    {
+      duplicate$ #3 #1 substring$ "" =
+        {
+          duplicate$ #2 #1 substring$ "" =
+            {
+              duplicate$ "" =
+                {
+                  "Empty string is not a char!" warning$
+                  pop$ #-1
+                }
+                { #1 #1 substring$ chr.to.int$ }
+              if$
+            }
+            {
+              duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+              #1 #1 substring$ chr.to.int$ #192 -
+              #6 mult.power2 +
+            }
+          if$
+        }
+        {
+          duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+          duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+          #1 #1 substring$ chr.to.int$ #224 -
+          #6 mult.power2 +
+          #6 mult.power2 +
+        }
+      if$
+    }
+    {
+      duplicate$ #4 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+      #1 #1 substring$ chr.to.int$ #240 -
+      #6 mult.power2 +
+      #6 mult.power2 +
+      #6 mult.power2 +
+    }
+  if$
+}
+
+FUNCTION {is.char.in.str}
+{
+  't :=
+
+  t "" =
+    { "is.char.in.str: Empty string is not a char!" warning$ }
+    'skip$
+  if$
+
+  #0 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str t =
+        { pop$ pop$ #1 "" }
+        'skip$
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.upper.ascii}
+{
+  char.to.unicode #65 swap$ #90 swap$ is.int.in.range
+}
+
+FUNCTION {is.upper}
+{
+  duplicate$ is.upper.ascii
+    { pop$ #1 }
+    { latin.upper swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.lower.ascii}
+{
+  char.to.unicode #97 swap$ #122 swap$ is.int.in.range
+}
+
+FUNCTION {is.lower}
+{
+  duplicate$ is.lower.ascii
+    { pop$ #1 }
+    { latin.lower swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.printable.ascii}
+{
+  char.to.unicode #32 swap$ #126 swap$ is.int.in.range
+}
+
+FUNCTION {is.letter.ascii}
+{
+  duplicate$ is.upper.ascii swap$ is.lower.ascii or
+}
+
+FUNCTION {is.symbol.ascii}
+{
+  duplicate$ is.printable.ascii swap$ is.letter.ascii not and
+}
+
+FUNCTION {is.all.lower}
+{
+  #1 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str is.lower
+        'skip$
+        { pop$ pop$ #0 "" }
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.tex.str.in.title.case}
+{
+  duplicate$ "" =
+    { pop$ #0 }
+    {
+      split.first.tex.char.from.str purify$
+      duplicate$ "" =
+        { pop$ pop$ #0 }
+        {
+          split.first.char.from.str is.upper
+            {
+              duplicate$ is.all.lower
+                {
+                  empty$
+                    {
+                      duplicate$ "" =
+                        { pop$ #0 }
+                        'is.all.lower
+                      if$
+                    }
+                    'is.all.lower
+                  if$
+                }
+                { pop$ pop$ #0 }
+              if$
+            }
+            { pop$ pop$ #0}
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {is.in.inter.token.chars}
+{
+  duplicate$ #0 =
+    { pop$ " " = }
+    {
+      #1 =
+        { " " range.delimiters * swap$ is.char.in.str }
+        'is.letter.ascii
+      if$
+    }
+  if$
+}
+
+FUNCTION {skip.inter.token.chars.by}
+{
+  'b :=
+  't :=
+
+  "" t
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str
+      duplicate$ b is.in.inter.token.chars
+        { swap$ 't := * t }
+        { swap$ * 't := "" }
+      if$
+    }
+  while$
+
+  pop$ t
+}
+
+FUNCTION {skip.inter.token.chars}
+{
+  #0 skip.inter.token.chars.by
+}
+
+FUNCTION {skip.inter.token.command}
+{
+  duplicate$ "" =
+    { "" }
+    {
+      duplicate$ #1 #1 substring$ is.symbol.ascii
+        { split.first.char.from.str swap$ }
+        { #2 skip.inter.token.chars.by }
+     if$
+    }
+  if$
+}
+
+FUNCTION {is.special.char.command}
+{
+  #2 global.max$ substring$ skip.inter.token.command
+
+  empty$
+    'skip$
+    { "is.special.char.command: cmdstr has extra components!" warning$ }
+  if$
+
+  duplicate$ duplicate$ duplicate$ duplicate$ duplicate$ duplicate$
+  "oOlLij" swap$ is.char.in.str
+  swap$ "oe" = or
+  swap$ "OE" = or
+  swap$ "ae" = or
+  swap$ "AE" = or
+  swap$ "aa" = or
+  swap$ "AA" = or
+}
+
+FUNCTION {map.char}
+{
+  't :=
+  split.first.char.from.str
+  { swap$ duplicate$ "" = not }
+    {
+      swap$ t =
+        { pop$ "" t }
+        {
+          swap$ split.first.char.from.str pop$ swap$
+          split.first.char.from.str
+        }
+      if$
+    }
+  while$
+  pop$ t =
+    'get.first.char.from.str
+    { pop$ t }
+  if$
+}
+
+FUNCTION {to.lower}
+{
+  duplicate$ is.upper.ascii
+    { chr.to.int$ #32 + int.to.chr$ }
+    { latin.lower swap$ latin.upper swap$ map.char }
+  if$
+}
+
+FUNCTION {to.upper}
+{
+  duplicate$ is.lower.ascii
+    { chr.to.int$ #32 - int.to.chr$ }
+    { latin.upper swap$ latin.lower swap$ map.char }
+  if$
+}
+
+FUNCTION {all.to.lower}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.lower swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.lower}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+          duplicate$ is.special.char.command
+            'all.to.lower
+            'skip$
+          if$
+        }
+        'to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.lower}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+        {
+          split.first.char.from.str
+          duplicate$ #92 int.to.chr$ =
+            {
+              swap$ skip.inter.token.command 't := * t
+              swap$ command.to.lower
+            }
+            'to.lower
+          if$
+          swap$ 't := * t
+        }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {all.to.upper}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.upper swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.upper}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+           duplicate$ is.special.char.command
+             'all.to.upper
+             'skip$
+           if$
+        }
+        'to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.upper}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+      {
+        split.first.char.from.str
+        duplicate$ #92 int.to.chr$ =
+          {
+            swap$ skip.inter.token.command 't := * t
+            swap$ command.to.upper
+          }
+          'to.upper
+        if$
+        swap$ 't := * t
+      }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {lower.token.if.in.title.case}
+{
+  duplicate$ is.tex.str.in.title.case
+    { split.first.tex.char.from.str tex.to.lower swap$ * }
+    'skip$
+  if$
+}
+
+FUNCTION {self.tokens}
+{
+  #0 =
+    'default.self.tokens
+    'range.delimiters
+  if$
+}
+
+FUNCTION {tokenize.by}
+{
+  'b :=
+  's :=
+
+  s "" =
+    { "" "" }
+    {
+      s split.first.char.from.str
+      duplicate$ b self.tokens swap$ is.char.in.str
+        'swap$
+        {
+          duplicate$ #92 int.to.chr$ =
+            { swap$ skip.inter.token.command 's := * s }
+            {
+              pop$ pop$ "" s
+              { duplicate$ "" = not }
+                {
+                  split.first.char.from.str
+                  duplicate$ "\ " b self.tokens * swap$ is.char.in.str
+                    { pop$ pop$ "" }
+                    {
+                      duplicate$ "{" =
+                        { swap$ find.match.brace }
+                        'swap$
+                      if$
+                      's := * s
+                    }
+                  if$
+                }
+              while$
+              pop$ s
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tokenize}
+{
+  #0 tokenize.by
+}
+
+FUNCTION {smart.sentence.case}
+{
+  tokenize 's :=
+
+  { s "" = not }
+    {
+      s skip.inter.token.chars 's := * s
+      tokenize swap$
+      duplicate$ ":" =
+        {
+          swap$ 's := *
+          s skip.inter.token.chars 's := * s
+          tokenize swap$
+          lowercase.word.after.colon
+            {
+              duplicate$ "A" =
+                { pop$ "a" }
+                'lower.token.if.in.title.case
+              if$
+            }
+            'skip$
+          if$
+        }
+        'lower.token.if.in.title.case
+      if$
+      swap$ 's := *
+    }
+  while$
+}
+
+FUNCTION {smart.upper.case}
+{
+  s swap$ t swap$
+
+  "" swap$
+  { duplicate$ "" = not }
+    {
+      tokenize swap$
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        'command.to.upper
+        {
+          "" swap$
+          { duplicate$ "" = not }
+            {
+              split.first.tex.char.from.str tex.to.upper
+              swap$ 't := * t
+            }
+          while$
+          pop$
+        }
+      if$
+      swap$ 't := * t
+      skip.inter.token.chars 't := * t
+    }
+  while$
+  pop$
+
+  swap$ 't :=
+  swap$ 's :=
+}
+
 FUNCTION {field.or.null}
 { duplicate$ empty$
     { pop$ "" }
@@ -594,7 +1217,7 @@ FUNCTION {format.name}
       name.lang lang.en =
         { t #1 "{vv~}{ll}{ f{~}}" format.name$
           uppercase.name
-            { "u" change.case$ }
+            'smart.upper.case
             'skip$
           if$
           t #1 "{, jj}" format.name$ *
@@ -773,7 +1396,7 @@ FUNCTION {output.bibitem}
 
 FUNCTION {change.sentence.case}
 { entry.lang lang.en =
-    { "t" change.case$ }
+    'smart.sentence.case
     'skip$
   if$
 }
@@ -1383,32 +2006,27 @@ FUNCTION {format.urldate}
   if$
 }
 
-FUNCTION {hyphenate}
-{ 't :=
-  ""
-    { t empty$ not }
-    { t #1 #1 substring$ "-" =
-        { wave.dash.in.pages
-            { "～" * }
-            { "-" * }
-          if$
-            { t #1 #1 substring$ "-" = }
-            { t #2 global.max$ substring$ 't := }
-          while$
-        }
-        { t #1 #1 substring$ *
-          t #2 global.max$ substring$ 't :=
-        }
+FUNCTION {normalize.page.range}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    {
+      #1 skip.inter.token.chars.by 't :=
+      empty$
+        { "" }
+        'page.range.delimiter
       if$
+      * t
+      #1 tokenize.by 't :=
+      * t
     }
   while$
+  pop$
 }
 
 FUNCTION {format.pages}
-{ pages empty$
-    { "" }
-    { pages hyphenate }
-  if$
+{
+  pages normalize.page.range
 }
 
 FUNCTION {format.extracted.pages}
@@ -1416,8 +2034,8 @@ FUNCTION {format.extracted.pages}
     { "" }
     { pages
       only.start.page
-        'extract.before.dash
-        'hyphenate
+        { #1 tokenize.by pop$ }
+        'normalize.page.range
       if$
     }
   if$

--- a/variants/ustc/ustcthesis-authoryear.bst
+++ b/variants/ustc/ustcthesis-authoryear.bst
@@ -44,7 +44,6 @@ INTEGERS {
   show.missing.address.publisher
   space.before.pages
   only.start.page
-  wave.dash.in.pages
   show.urldate
   show.url
   show.doi
@@ -52,6 +51,7 @@ INTEGERS {
   show.note
   show.english.translation
   end.with.period
+  lowercase.word.after.colon
   lang.zh.order
   lang.ja.order
   lang.en.order
@@ -61,6 +61,7 @@ INTEGERS {
 
 STRINGS {
   component.part.label
+  page.range.delimiter
 }
 
 FUNCTION {load.config}
@@ -89,7 +90,7 @@ FUNCTION {load.config}
   #0 'show.missing.address.publisher :=
   #1 'space.before.pages :=
   #0 'only.start.page :=
-  #0 'wave.dash.in.pages :=
+  "-" 'page.range.delimiter :=
   #1 'show.urldate :=
   #0 'show.url :=
   #0 'show.doi :=
@@ -97,6 +98,7 @@ FUNCTION {load.config}
   #0 'show.note :=
   #0 'show.english.translation :=
   #1 'end.with.period :=
+  #1 'lowercase.word.after.colon :=
   #1 'lang.zh.order :=
   #2 'lang.ja.order :=
   #3 'lang.en.order :=
@@ -243,6 +245,14 @@ FUNCTION {bbl.sine.loco.sine.nomine}
     { "[S.l.: s.n.]" }
   if$
 }
+
+FUNCTION {default.self.tokens} { ":,-'–—?.!" }
+
+FUNCTION {latin.upper} { "ÀÁÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİIĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ" }
+
+FUNCTION {latin.lower} { "àáãäåæçèéêëìíîïðñòóôõöøùúûüýþÿāăąćĉċčďđēĕėęěĝğġģĥħĩīĭįiıĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" }
+
+FUNCTION {range.delimiters} { "-–—～" }
 
 FUNCTION {not}
 {   { #0 }
@@ -449,6 +459,619 @@ FUNCTION {new.sentence.checkb}
   if$
 }
 
+INTEGERS { b }
+
+FUNCTION {is.int.in.range}
+{
+  'b :=
+  #1 +
+  b >
+    { #1 - b < }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {mult.power2}
+{
+  { duplicate$ #0 > }
+    {
+      swap$
+      duplicate$ +
+      swap$ #1 -
+    }
+  while$
+  pop$
+}
+
+FUNCTION {find.match.brace}
+{
+  's :=
+  't :=
+
+  #1
+  { duplicate$ #0 >
+    s empty$ not and }
+    {
+      s #1 #1 substring$ "{" =
+        { #1 + }
+        {
+          s #1 #1 substring$ "}" =
+            { #1 - }
+            'skip$
+          if$
+        }
+      if$
+      t s #1 #1 substring$ * 't :=
+      s #2 global.max$ substring$ 's :=
+    }
+  while$
+
+  duplicate$ #0 >
+    {
+      "Unbalanced brace(s): one or more closing braces are missing" warning$
+      { duplicate$ #0 > }
+        {
+          t "}" * 't :=
+          #1 -
+        }
+      while$
+    }
+    'skip$
+  if$
+  pop$
+
+  t
+  s
+}
+
+FUNCTION {split.first.char.from.str}
+{
+  duplicate$ "" =
+    {
+      "split.first.char.from.str: Trying to split an empty string!" warning$
+      ""
+    }
+    {
+      duplicate$ #1 #1 substring$ chr.to.int$ #128 <
+        {
+          duplicate$ #1 #1 substring$ swap$
+          #2 global.max$ substring$ swap$
+        }
+        {
+          duplicate$ #1 #1 substring$ chr.to.int$ #224 <
+            {
+              duplicate$ #1 #2 substring$ swap$
+              #3 global.max$ substring$ swap$
+            }
+            {
+              duplicate$ #1 #1 substring$ chr.to.int$ #240 <
+                {
+                  duplicate$ #1 #3 substring$ swap$
+                  #4 global.max$ substring$ swap$
+                }
+                {
+                  duplicate$ #1 #4 substring$ swap$
+                  #5 global.max$ substring$ swap$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {get.first.char.from.str}
+{
+  split.first.char.from.str swap$ pop$
+}
+
+FUNCTION {split.first.tex.char.from.str}
+{
+  duplicate$ #1 #1 substring$ "{" =
+    {
+      split.first.char.from.str swap$
+      find.match.brace swap$
+    }
+    'split.first.char.from.str
+  if$
+}
+
+FUNCTION {char.to.unicode}
+{
+  duplicate$ #4 #1 substring$ "" =
+    {
+      duplicate$ #3 #1 substring$ "" =
+        {
+          duplicate$ #2 #1 substring$ "" =
+            {
+              duplicate$ "" =
+                {
+                  "Empty string is not a char!" warning$
+                  pop$ #-1
+                }
+                { #1 #1 substring$ chr.to.int$ }
+              if$
+            }
+            {
+              duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+              #1 #1 substring$ chr.to.int$ #192 -
+              #6 mult.power2 +
+            }
+          if$
+        }
+        {
+          duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+          duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+          #1 #1 substring$ chr.to.int$ #224 -
+          #6 mult.power2 +
+          #6 mult.power2 +
+        }
+      if$
+    }
+    {
+      duplicate$ #4 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+      #1 #1 substring$ chr.to.int$ #240 -
+      #6 mult.power2 +
+      #6 mult.power2 +
+      #6 mult.power2 +
+    }
+  if$
+}
+
+FUNCTION {is.char.in.str}
+{
+  't :=
+
+  t "" =
+    { "is.char.in.str: Empty string is not a char!" warning$ }
+    'skip$
+  if$
+
+  #0 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str t =
+        { pop$ pop$ #1 "" }
+        'skip$
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.upper.ascii}
+{
+  char.to.unicode #65 swap$ #90 swap$ is.int.in.range
+}
+
+FUNCTION {is.upper}
+{
+  duplicate$ is.upper.ascii
+    { pop$ #1 }
+    { latin.upper swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.lower.ascii}
+{
+  char.to.unicode #97 swap$ #122 swap$ is.int.in.range
+}
+
+FUNCTION {is.lower}
+{
+  duplicate$ is.lower.ascii
+    { pop$ #1 }
+    { latin.lower swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.printable.ascii}
+{
+  char.to.unicode #32 swap$ #126 swap$ is.int.in.range
+}
+
+FUNCTION {is.letter.ascii}
+{
+  duplicate$ is.upper.ascii swap$ is.lower.ascii or
+}
+
+FUNCTION {is.symbol.ascii}
+{
+  duplicate$ is.printable.ascii swap$ is.letter.ascii not and
+}
+
+FUNCTION {is.all.lower}
+{
+  #1 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str is.lower
+        'skip$
+        { pop$ pop$ #0 "" }
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.tex.str.in.title.case}
+{
+  duplicate$ "" =
+    { pop$ #0 }
+    {
+      split.first.tex.char.from.str purify$
+      duplicate$ "" =
+        { pop$ pop$ #0 }
+        {
+          split.first.char.from.str is.upper
+            {
+              duplicate$ is.all.lower
+                {
+                  empty$
+                    {
+                      duplicate$ "" =
+                        { pop$ #0 }
+                        'is.all.lower
+                      if$
+                    }
+                    'is.all.lower
+                  if$
+                }
+                { pop$ pop$ #0 }
+              if$
+            }
+            { pop$ pop$ #0}
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {is.in.inter.token.chars}
+{
+  duplicate$ #0 =
+    { pop$ " " = }
+    {
+      #1 =
+        { " " range.delimiters * swap$ is.char.in.str }
+        'is.letter.ascii
+      if$
+    }
+  if$
+}
+
+FUNCTION {skip.inter.token.chars.by}
+{
+  'b :=
+  't :=
+
+  "" t
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str
+      duplicate$ b is.in.inter.token.chars
+        { swap$ 't := * t }
+        { swap$ * 't := "" }
+      if$
+    }
+  while$
+
+  pop$ t
+}
+
+FUNCTION {skip.inter.token.chars}
+{
+  #0 skip.inter.token.chars.by
+}
+
+FUNCTION {skip.inter.token.command}
+{
+  duplicate$ "" =
+    { "" }
+    {
+      duplicate$ #1 #1 substring$ is.symbol.ascii
+        { split.first.char.from.str swap$ }
+        { #2 skip.inter.token.chars.by }
+     if$
+    }
+  if$
+}
+
+FUNCTION {is.special.char.command}
+{
+  #2 global.max$ substring$ skip.inter.token.command
+
+  empty$
+    'skip$
+    { "is.special.char.command: cmdstr has extra components!" warning$ }
+  if$
+
+  duplicate$ duplicate$ duplicate$ duplicate$ duplicate$ duplicate$
+  "oOlLij" swap$ is.char.in.str
+  swap$ "oe" = or
+  swap$ "OE" = or
+  swap$ "ae" = or
+  swap$ "AE" = or
+  swap$ "aa" = or
+  swap$ "AA" = or
+}
+
+FUNCTION {map.char}
+{
+  't :=
+  split.first.char.from.str
+  { swap$ duplicate$ "" = not }
+    {
+      swap$ t =
+        { pop$ "" t }
+        {
+          swap$ split.first.char.from.str pop$ swap$
+          split.first.char.from.str
+        }
+      if$
+    }
+  while$
+  pop$ t =
+    'get.first.char.from.str
+    { pop$ t }
+  if$
+}
+
+FUNCTION {to.lower}
+{
+  duplicate$ is.upper.ascii
+    { chr.to.int$ #32 + int.to.chr$ }
+    { latin.lower swap$ latin.upper swap$ map.char }
+  if$
+}
+
+FUNCTION {to.upper}
+{
+  duplicate$ is.lower.ascii
+    { chr.to.int$ #32 - int.to.chr$ }
+    { latin.upper swap$ latin.lower swap$ map.char }
+  if$
+}
+
+FUNCTION {all.to.lower}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.lower swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.lower}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+          duplicate$ is.special.char.command
+            'all.to.lower
+            'skip$
+          if$
+        }
+        'to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.lower}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+        {
+          split.first.char.from.str
+          duplicate$ #92 int.to.chr$ =
+            {
+              swap$ skip.inter.token.command 't := * t
+              swap$ command.to.lower
+            }
+            'to.lower
+          if$
+          swap$ 't := * t
+        }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {all.to.upper}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.upper swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.upper}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+           duplicate$ is.special.char.command
+             'all.to.upper
+             'skip$
+           if$
+        }
+        'to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.upper}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+      {
+        split.first.char.from.str
+        duplicate$ #92 int.to.chr$ =
+          {
+            swap$ skip.inter.token.command 't := * t
+            swap$ command.to.upper
+          }
+          'to.upper
+        if$
+        swap$ 't := * t
+      }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {lower.token.if.in.title.case}
+{
+  duplicate$ is.tex.str.in.title.case
+    { split.first.tex.char.from.str tex.to.lower swap$ * }
+    'skip$
+  if$
+}
+
+FUNCTION {self.tokens}
+{
+  #0 =
+    'default.self.tokens
+    'range.delimiters
+  if$
+}
+
+FUNCTION {tokenize.by}
+{
+  'b :=
+  's :=
+
+  s "" =
+    { "" "" }
+    {
+      s split.first.char.from.str
+      duplicate$ b self.tokens swap$ is.char.in.str
+        'swap$
+        {
+          duplicate$ #92 int.to.chr$ =
+            { swap$ skip.inter.token.command 's := * s }
+            {
+              pop$ pop$ "" s
+              { duplicate$ "" = not }
+                {
+                  split.first.char.from.str
+                  duplicate$ "\ " b self.tokens * swap$ is.char.in.str
+                    { pop$ pop$ "" }
+                    {
+                      duplicate$ "{" =
+                        { swap$ find.match.brace }
+                        'swap$
+                      if$
+                      's := * s
+                    }
+                  if$
+                }
+              while$
+              pop$ s
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tokenize}
+{
+  #0 tokenize.by
+}
+
+FUNCTION {smart.sentence.case}
+{
+  tokenize 's :=
+
+  { s "" = not }
+    {
+      s skip.inter.token.chars 's := * s
+      tokenize swap$
+      duplicate$ ":" =
+        {
+          swap$ 's := *
+          s skip.inter.token.chars 's := * s
+          tokenize swap$
+          lowercase.word.after.colon
+            {
+              duplicate$ "A" =
+                { pop$ "a" }
+                'lower.token.if.in.title.case
+              if$
+            }
+            'skip$
+          if$
+        }
+        'lower.token.if.in.title.case
+      if$
+      swap$ 's := *
+    }
+  while$
+}
+
+FUNCTION {smart.upper.case}
+{
+  s swap$ t swap$
+
+  "" swap$
+  { duplicate$ "" = not }
+    {
+      tokenize swap$
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        'command.to.upper
+        {
+          "" swap$
+          { duplicate$ "" = not }
+            {
+              split.first.tex.char.from.str tex.to.upper
+              swap$ 't := * t
+            }
+          while$
+          pop$
+        }
+      if$
+      swap$ 't := * t
+      skip.inter.token.chars 't := * t
+    }
+  while$
+  pop$
+
+  swap$ 't :=
+  swap$ 's :=
+}
+
 FUNCTION {field.or.null}
 { duplicate$ empty$
     { pop$ "" }
@@ -604,7 +1227,7 @@ FUNCTION {format.name}
       name.lang lang.en =
         { t #1 "{vv~}{ll}{ f{~}}" format.name$
           uppercase.name
-            { "u" change.case$ }
+            'smart.upper.case
             'skip$
           if$
           t #1 "{, jj}" format.name$ *
@@ -783,7 +1406,7 @@ FUNCTION {output.bibitem}
 
 FUNCTION {change.sentence.case}
 { entry.lang lang.en =
-    { "t" change.case$ }
+    'smart.sentence.case
     'skip$
   if$
 }
@@ -1393,32 +2016,27 @@ FUNCTION {format.urldate}
   if$
 }
 
-FUNCTION {hyphenate}
-{ 't :=
-  ""
-    { t empty$ not }
-    { t #1 #1 substring$ "-" =
-        { wave.dash.in.pages
-            { "～" * }
-            { "-" * }
-          if$
-            { t #1 #1 substring$ "-" = }
-            { t #2 global.max$ substring$ 't := }
-          while$
-        }
-        { t #1 #1 substring$ *
-          t #2 global.max$ substring$ 't :=
-        }
+FUNCTION {normalize.page.range}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    {
+      #1 skip.inter.token.chars.by 't :=
+      empty$
+        { "" }
+        'page.range.delimiter
       if$
+      * t
+      #1 tokenize.by 't :=
+      * t
     }
   while$
+  pop$
 }
 
 FUNCTION {format.pages}
-{ pages empty$
-    { "" }
-    { pages hyphenate }
-  if$
+{
+  pages normalize.page.range
 }
 
 FUNCTION {format.extracted.pages}
@@ -1426,8 +2044,8 @@ FUNCTION {format.extracted.pages}
     { "" }
     { pages
       only.start.page
-        'extract.before.dash
-        'hyphenate
+        { #1 tokenize.by pop$ }
+        'normalize.page.range
       if$
     }
   if$

--- a/variants/ustc/ustcthesis-bachelor.bst
+++ b/variants/ustc/ustcthesis-bachelor.bst
@@ -44,7 +44,6 @@ INTEGERS {
   show.missing.address.publisher
   space.before.pages
   only.start.page
-  wave.dash.in.pages
   show.urldate
   show.url
   show.doi
@@ -52,10 +51,12 @@ INTEGERS {
   show.note
   show.english.translation
   end.with.period
+  lowercase.word.after.colon
 }
 
 STRINGS {
   component.part.label
+  page.range.delimiter
 }
 
 FUNCTION {load.config}
@@ -84,7 +85,7 @@ FUNCTION {load.config}
   #0 'show.missing.address.publisher :=
   #1 'space.before.pages :=
   #0 'only.start.page :=
-  #0 'wave.dash.in.pages :=
+  "-" 'page.range.delimiter :=
   #1 'show.urldate :=
   #0 'show.url :=
   #0 'show.doi :=
@@ -92,6 +93,7 @@ FUNCTION {load.config}
   #0 'show.note :=
   #0 'show.english.translation :=
   #1 'end.with.period :=
+  #1 'lowercase.word.after.colon :=
 }
 
 ENTRY
@@ -233,6 +235,14 @@ FUNCTION {bbl.sine.loco.sine.nomine}
     { "[S.l.: s.n.]" }
   if$
 }
+
+FUNCTION {default.self.tokens} { ":,-'–—?.!" }
+
+FUNCTION {latin.upper} { "ÀÁÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİIĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ" }
+
+FUNCTION {latin.lower} { "àáãäåæçèéêëìíîïðñòóôõöøùúûüýþÿāăąćĉċčďđēĕėęěĝğġģĥħĩīĭįiıĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" }
+
+FUNCTION {range.delimiters} { "-–—～" }
 
 FUNCTION {not}
 {   { #0 }
@@ -439,6 +449,619 @@ FUNCTION {new.sentence.checkb}
   if$
 }
 
+INTEGERS { b }
+
+FUNCTION {is.int.in.range}
+{
+  'b :=
+  #1 +
+  b >
+    { #1 - b < }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {mult.power2}
+{
+  { duplicate$ #0 > }
+    {
+      swap$
+      duplicate$ +
+      swap$ #1 -
+    }
+  while$
+  pop$
+}
+
+FUNCTION {find.match.brace}
+{
+  's :=
+  't :=
+
+  #1
+  { duplicate$ #0 >
+    s empty$ not and }
+    {
+      s #1 #1 substring$ "{" =
+        { #1 + }
+        {
+          s #1 #1 substring$ "}" =
+            { #1 - }
+            'skip$
+          if$
+        }
+      if$
+      t s #1 #1 substring$ * 't :=
+      s #2 global.max$ substring$ 's :=
+    }
+  while$
+
+  duplicate$ #0 >
+    {
+      "Unbalanced brace(s): one or more closing braces are missing" warning$
+      { duplicate$ #0 > }
+        {
+          t "}" * 't :=
+          #1 -
+        }
+      while$
+    }
+    'skip$
+  if$
+  pop$
+
+  t
+  s
+}
+
+FUNCTION {split.first.char.from.str}
+{
+  duplicate$ "" =
+    {
+      "split.first.char.from.str: Trying to split an empty string!" warning$
+      ""
+    }
+    {
+      duplicate$ #1 #1 substring$ chr.to.int$ #128 <
+        {
+          duplicate$ #1 #1 substring$ swap$
+          #2 global.max$ substring$ swap$
+        }
+        {
+          duplicate$ #1 #1 substring$ chr.to.int$ #224 <
+            {
+              duplicate$ #1 #2 substring$ swap$
+              #3 global.max$ substring$ swap$
+            }
+            {
+              duplicate$ #1 #1 substring$ chr.to.int$ #240 <
+                {
+                  duplicate$ #1 #3 substring$ swap$
+                  #4 global.max$ substring$ swap$
+                }
+                {
+                  duplicate$ #1 #4 substring$ swap$
+                  #5 global.max$ substring$ swap$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {get.first.char.from.str}
+{
+  split.first.char.from.str swap$ pop$
+}
+
+FUNCTION {split.first.tex.char.from.str}
+{
+  duplicate$ #1 #1 substring$ "{" =
+    {
+      split.first.char.from.str swap$
+      find.match.brace swap$
+    }
+    'split.first.char.from.str
+  if$
+}
+
+FUNCTION {char.to.unicode}
+{
+  duplicate$ #4 #1 substring$ "" =
+    {
+      duplicate$ #3 #1 substring$ "" =
+        {
+          duplicate$ #2 #1 substring$ "" =
+            {
+              duplicate$ "" =
+                {
+                  "Empty string is not a char!" warning$
+                  pop$ #-1
+                }
+                { #1 #1 substring$ chr.to.int$ }
+              if$
+            }
+            {
+              duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+              #1 #1 substring$ chr.to.int$ #192 -
+              #6 mult.power2 +
+            }
+          if$
+        }
+        {
+          duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+          duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+          #1 #1 substring$ chr.to.int$ #224 -
+          #6 mult.power2 +
+          #6 mult.power2 +
+        }
+      if$
+    }
+    {
+      duplicate$ #4 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+      #1 #1 substring$ chr.to.int$ #240 -
+      #6 mult.power2 +
+      #6 mult.power2 +
+      #6 mult.power2 +
+    }
+  if$
+}
+
+FUNCTION {is.char.in.str}
+{
+  't :=
+
+  t "" =
+    { "is.char.in.str: Empty string is not a char!" warning$ }
+    'skip$
+  if$
+
+  #0 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str t =
+        { pop$ pop$ #1 "" }
+        'skip$
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.upper.ascii}
+{
+  char.to.unicode #65 swap$ #90 swap$ is.int.in.range
+}
+
+FUNCTION {is.upper}
+{
+  duplicate$ is.upper.ascii
+    { pop$ #1 }
+    { latin.upper swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.lower.ascii}
+{
+  char.to.unicode #97 swap$ #122 swap$ is.int.in.range
+}
+
+FUNCTION {is.lower}
+{
+  duplicate$ is.lower.ascii
+    { pop$ #1 }
+    { latin.lower swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.printable.ascii}
+{
+  char.to.unicode #32 swap$ #126 swap$ is.int.in.range
+}
+
+FUNCTION {is.letter.ascii}
+{
+  duplicate$ is.upper.ascii swap$ is.lower.ascii or
+}
+
+FUNCTION {is.symbol.ascii}
+{
+  duplicate$ is.printable.ascii swap$ is.letter.ascii not and
+}
+
+FUNCTION {is.all.lower}
+{
+  #1 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str is.lower
+        'skip$
+        { pop$ pop$ #0 "" }
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.tex.str.in.title.case}
+{
+  duplicate$ "" =
+    { pop$ #0 }
+    {
+      split.first.tex.char.from.str purify$
+      duplicate$ "" =
+        { pop$ pop$ #0 }
+        {
+          split.first.char.from.str is.upper
+            {
+              duplicate$ is.all.lower
+                {
+                  empty$
+                    {
+                      duplicate$ "" =
+                        { pop$ #0 }
+                        'is.all.lower
+                      if$
+                    }
+                    'is.all.lower
+                  if$
+                }
+                { pop$ pop$ #0 }
+              if$
+            }
+            { pop$ pop$ #0}
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {is.in.inter.token.chars}
+{
+  duplicate$ #0 =
+    { pop$ " " = }
+    {
+      #1 =
+        { " " range.delimiters * swap$ is.char.in.str }
+        'is.letter.ascii
+      if$
+    }
+  if$
+}
+
+FUNCTION {skip.inter.token.chars.by}
+{
+  'b :=
+  't :=
+
+  "" t
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str
+      duplicate$ b is.in.inter.token.chars
+        { swap$ 't := * t }
+        { swap$ * 't := "" }
+      if$
+    }
+  while$
+
+  pop$ t
+}
+
+FUNCTION {skip.inter.token.chars}
+{
+  #0 skip.inter.token.chars.by
+}
+
+FUNCTION {skip.inter.token.command}
+{
+  duplicate$ "" =
+    { "" }
+    {
+      duplicate$ #1 #1 substring$ is.symbol.ascii
+        { split.first.char.from.str swap$ }
+        { #2 skip.inter.token.chars.by }
+     if$
+    }
+  if$
+}
+
+FUNCTION {is.special.char.command}
+{
+  #2 global.max$ substring$ skip.inter.token.command
+
+  empty$
+    'skip$
+    { "is.special.char.command: cmdstr has extra components!" warning$ }
+  if$
+
+  duplicate$ duplicate$ duplicate$ duplicate$ duplicate$ duplicate$
+  "oOlLij" swap$ is.char.in.str
+  swap$ "oe" = or
+  swap$ "OE" = or
+  swap$ "ae" = or
+  swap$ "AE" = or
+  swap$ "aa" = or
+  swap$ "AA" = or
+}
+
+FUNCTION {map.char}
+{
+  't :=
+  split.first.char.from.str
+  { swap$ duplicate$ "" = not }
+    {
+      swap$ t =
+        { pop$ "" t }
+        {
+          swap$ split.first.char.from.str pop$ swap$
+          split.first.char.from.str
+        }
+      if$
+    }
+  while$
+  pop$ t =
+    'get.first.char.from.str
+    { pop$ t }
+  if$
+}
+
+FUNCTION {to.lower}
+{
+  duplicate$ is.upper.ascii
+    { chr.to.int$ #32 + int.to.chr$ }
+    { latin.lower swap$ latin.upper swap$ map.char }
+  if$
+}
+
+FUNCTION {to.upper}
+{
+  duplicate$ is.lower.ascii
+    { chr.to.int$ #32 - int.to.chr$ }
+    { latin.upper swap$ latin.lower swap$ map.char }
+  if$
+}
+
+FUNCTION {all.to.lower}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.lower swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.lower}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+          duplicate$ is.special.char.command
+            'all.to.lower
+            'skip$
+          if$
+        }
+        'to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.lower}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+        {
+          split.first.char.from.str
+          duplicate$ #92 int.to.chr$ =
+            {
+              swap$ skip.inter.token.command 't := * t
+              swap$ command.to.lower
+            }
+            'to.lower
+          if$
+          swap$ 't := * t
+        }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {all.to.upper}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.upper swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.upper}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+           duplicate$ is.special.char.command
+             'all.to.upper
+             'skip$
+           if$
+        }
+        'to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.upper}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+      {
+        split.first.char.from.str
+        duplicate$ #92 int.to.chr$ =
+          {
+            swap$ skip.inter.token.command 't := * t
+            swap$ command.to.upper
+          }
+          'to.upper
+        if$
+        swap$ 't := * t
+      }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {lower.token.if.in.title.case}
+{
+  duplicate$ is.tex.str.in.title.case
+    { split.first.tex.char.from.str tex.to.lower swap$ * }
+    'skip$
+  if$
+}
+
+FUNCTION {self.tokens}
+{
+  #0 =
+    'default.self.tokens
+    'range.delimiters
+  if$
+}
+
+FUNCTION {tokenize.by}
+{
+  'b :=
+  's :=
+
+  s "" =
+    { "" "" }
+    {
+      s split.first.char.from.str
+      duplicate$ b self.tokens swap$ is.char.in.str
+        'swap$
+        {
+          duplicate$ #92 int.to.chr$ =
+            { swap$ skip.inter.token.command 's := * s }
+            {
+              pop$ pop$ "" s
+              { duplicate$ "" = not }
+                {
+                  split.first.char.from.str
+                  duplicate$ "\ " b self.tokens * swap$ is.char.in.str
+                    { pop$ pop$ "" }
+                    {
+                      duplicate$ "{" =
+                        { swap$ find.match.brace }
+                        'swap$
+                      if$
+                      's := * s
+                    }
+                  if$
+                }
+              while$
+              pop$ s
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tokenize}
+{
+  #0 tokenize.by
+}
+
+FUNCTION {smart.sentence.case}
+{
+  tokenize 's :=
+
+  { s "" = not }
+    {
+      s skip.inter.token.chars 's := * s
+      tokenize swap$
+      duplicate$ ":" =
+        {
+          swap$ 's := *
+          s skip.inter.token.chars 's := * s
+          tokenize swap$
+          lowercase.word.after.colon
+            {
+              duplicate$ "A" =
+                { pop$ "a" }
+                'lower.token.if.in.title.case
+              if$
+            }
+            'skip$
+          if$
+        }
+        'lower.token.if.in.title.case
+      if$
+      swap$ 's := *
+    }
+  while$
+}
+
+FUNCTION {smart.upper.case}
+{
+  s swap$ t swap$
+
+  "" swap$
+  { duplicate$ "" = not }
+    {
+      tokenize swap$
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        'command.to.upper
+        {
+          "" swap$
+          { duplicate$ "" = not }
+            {
+              split.first.tex.char.from.str tex.to.upper
+              swap$ 't := * t
+            }
+          while$
+          pop$
+        }
+      if$
+      swap$ 't := * t
+      skip.inter.token.chars 't := * t
+    }
+  while$
+  pop$
+
+  swap$ 't :=
+  swap$ 's :=
+}
+
 FUNCTION {field.or.null}
 { duplicate$ empty$
     { pop$ "" }
@@ -594,7 +1217,7 @@ FUNCTION {format.name}
       name.lang lang.en =
         { t #1 "{vv~}{ll}{ f{~}}" format.name$
           uppercase.name
-            { "u" change.case$ }
+            'smart.upper.case
             'skip$
           if$
           t #1 "{, jj}" format.name$ *
@@ -773,7 +1396,7 @@ FUNCTION {output.bibitem}
 
 FUNCTION {change.sentence.case}
 { entry.lang lang.en =
-    { "t" change.case$ }
+    'smart.sentence.case
     'skip$
   if$
 }
@@ -1383,32 +2006,27 @@ FUNCTION {format.urldate}
   if$
 }
 
-FUNCTION {hyphenate}
-{ 't :=
-  ""
-    { t empty$ not }
-    { t #1 #1 substring$ "-" =
-        { wave.dash.in.pages
-            { "～" * }
-            { "-" * }
-          if$
-            { t #1 #1 substring$ "-" = }
-            { t #2 global.max$ substring$ 't := }
-          while$
-        }
-        { t #1 #1 substring$ *
-          t #2 global.max$ substring$ 't :=
-        }
+FUNCTION {normalize.page.range}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    {
+      #1 skip.inter.token.chars.by 't :=
+      empty$
+        { "" }
+        'page.range.delimiter
       if$
+      * t
+      #1 tokenize.by 't :=
+      * t
     }
   while$
+  pop$
 }
 
 FUNCTION {format.pages}
-{ pages empty$
-    { "" }
-    { pages hyphenate }
-  if$
+{
+  pages normalize.page.range
 }
 
 FUNCTION {format.extracted.pages}
@@ -1416,8 +2034,8 @@ FUNCTION {format.extracted.pages}
     { "" }
     { pages
       only.start.page
-        'extract.before.dash
-        'hyphenate
+        { #1 tokenize.by pop$ }
+        'normalize.page.range
       if$
     }
   if$

--- a/variants/ustc/ustcthesis-numerical.bst
+++ b/variants/ustc/ustcthesis-numerical.bst
@@ -44,7 +44,6 @@ INTEGERS {
   show.missing.address.publisher
   space.before.pages
   only.start.page
-  wave.dash.in.pages
   show.urldate
   show.url
   show.doi
@@ -52,10 +51,12 @@ INTEGERS {
   show.note
   show.english.translation
   end.with.period
+  lowercase.word.after.colon
 }
 
 STRINGS {
   component.part.label
+  page.range.delimiter
 }
 
 FUNCTION {load.config}
@@ -84,7 +85,7 @@ FUNCTION {load.config}
   #0 'show.missing.address.publisher :=
   #1 'space.before.pages :=
   #0 'only.start.page :=
-  #0 'wave.dash.in.pages :=
+  "-" 'page.range.delimiter :=
   #1 'show.urldate :=
   #0 'show.url :=
   #0 'show.doi :=
@@ -92,6 +93,7 @@ FUNCTION {load.config}
   #0 'show.note :=
   #0 'show.english.translation :=
   #1 'end.with.period :=
+  #1 'lowercase.word.after.colon :=
 }
 
 ENTRY
@@ -233,6 +235,14 @@ FUNCTION {bbl.sine.loco.sine.nomine}
     { "[S.l.: s.n.]" }
   if$
 }
+
+FUNCTION {default.self.tokens} { ":,-'–—?.!" }
+
+FUNCTION {latin.upper} { "ÀÁÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİIĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ" }
+
+FUNCTION {latin.lower} { "àáãäåæçèéêëìíîïðñòóôõöøùúûüýþÿāăąćĉċčďđēĕėęěĝğġģĥħĩīĭįiıĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" }
+
+FUNCTION {range.delimiters} { "-–—～" }
 
 FUNCTION {not}
 {   { #0 }
@@ -439,6 +449,619 @@ FUNCTION {new.sentence.checkb}
   if$
 }
 
+INTEGERS { b }
+
+FUNCTION {is.int.in.range}
+{
+  'b :=
+  #1 +
+  b >
+    { #1 - b < }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {mult.power2}
+{
+  { duplicate$ #0 > }
+    {
+      swap$
+      duplicate$ +
+      swap$ #1 -
+    }
+  while$
+  pop$
+}
+
+FUNCTION {find.match.brace}
+{
+  's :=
+  't :=
+
+  #1
+  { duplicate$ #0 >
+    s empty$ not and }
+    {
+      s #1 #1 substring$ "{" =
+        { #1 + }
+        {
+          s #1 #1 substring$ "}" =
+            { #1 - }
+            'skip$
+          if$
+        }
+      if$
+      t s #1 #1 substring$ * 't :=
+      s #2 global.max$ substring$ 's :=
+    }
+  while$
+
+  duplicate$ #0 >
+    {
+      "Unbalanced brace(s): one or more closing braces are missing" warning$
+      { duplicate$ #0 > }
+        {
+          t "}" * 't :=
+          #1 -
+        }
+      while$
+    }
+    'skip$
+  if$
+  pop$
+
+  t
+  s
+}
+
+FUNCTION {split.first.char.from.str}
+{
+  duplicate$ "" =
+    {
+      "split.first.char.from.str: Trying to split an empty string!" warning$
+      ""
+    }
+    {
+      duplicate$ #1 #1 substring$ chr.to.int$ #128 <
+        {
+          duplicate$ #1 #1 substring$ swap$
+          #2 global.max$ substring$ swap$
+        }
+        {
+          duplicate$ #1 #1 substring$ chr.to.int$ #224 <
+            {
+              duplicate$ #1 #2 substring$ swap$
+              #3 global.max$ substring$ swap$
+            }
+            {
+              duplicate$ #1 #1 substring$ chr.to.int$ #240 <
+                {
+                  duplicate$ #1 #3 substring$ swap$
+                  #4 global.max$ substring$ swap$
+                }
+                {
+                  duplicate$ #1 #4 substring$ swap$
+                  #5 global.max$ substring$ swap$
+                }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {get.first.char.from.str}
+{
+  split.first.char.from.str swap$ pop$
+}
+
+FUNCTION {split.first.tex.char.from.str}
+{
+  duplicate$ #1 #1 substring$ "{" =
+    {
+      split.first.char.from.str swap$
+      find.match.brace swap$
+    }
+    'split.first.char.from.str
+  if$
+}
+
+FUNCTION {char.to.unicode}
+{
+  duplicate$ #4 #1 substring$ "" =
+    {
+      duplicate$ #3 #1 substring$ "" =
+        {
+          duplicate$ #2 #1 substring$ "" =
+            {
+              duplicate$ "" =
+                {
+                  "Empty string is not a char!" warning$
+                  pop$ #-1
+                }
+                { #1 #1 substring$ chr.to.int$ }
+              if$
+            }
+            {
+              duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+              #1 #1 substring$ chr.to.int$ #192 -
+              #6 mult.power2 +
+            }
+          if$
+        }
+        {
+          duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+          duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+          #1 #1 substring$ chr.to.int$ #224 -
+          #6 mult.power2 +
+          #6 mult.power2 +
+        }
+      if$
+    }
+    {
+      duplicate$ #4 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #3 #1 substring$ chr.to.int$ #128 - swap$
+      duplicate$ #2 #1 substring$ chr.to.int$ #128 - swap$
+      #1 #1 substring$ chr.to.int$ #240 -
+      #6 mult.power2 +
+      #6 mult.power2 +
+      #6 mult.power2 +
+    }
+  if$
+}
+
+FUNCTION {is.char.in.str}
+{
+  't :=
+
+  t "" =
+    { "is.char.in.str: Empty string is not a char!" warning$ }
+    'skip$
+  if$
+
+  #0 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str t =
+        { pop$ pop$ #1 "" }
+        'skip$
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.upper.ascii}
+{
+  char.to.unicode #65 swap$ #90 swap$ is.int.in.range
+}
+
+FUNCTION {is.upper}
+{
+  duplicate$ is.upper.ascii
+    { pop$ #1 }
+    { latin.upper swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.lower.ascii}
+{
+  char.to.unicode #97 swap$ #122 swap$ is.int.in.range
+}
+
+FUNCTION {is.lower}
+{
+  duplicate$ is.lower.ascii
+    { pop$ #1 }
+    { latin.lower swap$ is.char.in.str }
+  if$
+}
+
+FUNCTION {is.printable.ascii}
+{
+  char.to.unicode #32 swap$ #126 swap$ is.int.in.range
+}
+
+FUNCTION {is.letter.ascii}
+{
+  duplicate$ is.upper.ascii swap$ is.lower.ascii or
+}
+
+FUNCTION {is.symbol.ascii}
+{
+  duplicate$ is.printable.ascii swap$ is.letter.ascii not and
+}
+
+FUNCTION {is.all.lower}
+{
+  #1 swap$
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str is.lower
+        'skip$
+        { pop$ pop$ #0 "" }
+      if$
+    }
+  while$
+  pop$
+}
+
+FUNCTION {is.tex.str.in.title.case}
+{
+  duplicate$ "" =
+    { pop$ #0 }
+    {
+      split.first.tex.char.from.str purify$
+      duplicate$ "" =
+        { pop$ pop$ #0 }
+        {
+          split.first.char.from.str is.upper
+            {
+              duplicate$ is.all.lower
+                {
+                  empty$
+                    {
+                      duplicate$ "" =
+                        { pop$ #0 }
+                        'is.all.lower
+                      if$
+                    }
+                    'is.all.lower
+                  if$
+                }
+                { pop$ pop$ #0 }
+              if$
+            }
+            { pop$ pop$ #0}
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {is.in.inter.token.chars}
+{
+  duplicate$ #0 =
+    { pop$ " " = }
+    {
+      #1 =
+        { " " range.delimiters * swap$ is.char.in.str }
+        'is.letter.ascii
+      if$
+    }
+  if$
+}
+
+FUNCTION {skip.inter.token.chars.by}
+{
+  'b :=
+  't :=
+
+  "" t
+  { duplicate$ "" = not }
+    {
+      split.first.char.from.str
+      duplicate$ b is.in.inter.token.chars
+        { swap$ 't := * t }
+        { swap$ * 't := "" }
+      if$
+    }
+  while$
+
+  pop$ t
+}
+
+FUNCTION {skip.inter.token.chars}
+{
+  #0 skip.inter.token.chars.by
+}
+
+FUNCTION {skip.inter.token.command}
+{
+  duplicate$ "" =
+    { "" }
+    {
+      duplicate$ #1 #1 substring$ is.symbol.ascii
+        { split.first.char.from.str swap$ }
+        { #2 skip.inter.token.chars.by }
+     if$
+    }
+  if$
+}
+
+FUNCTION {is.special.char.command}
+{
+  #2 global.max$ substring$ skip.inter.token.command
+
+  empty$
+    'skip$
+    { "is.special.char.command: cmdstr has extra components!" warning$ }
+  if$
+
+  duplicate$ duplicate$ duplicate$ duplicate$ duplicate$ duplicate$
+  "oOlLij" swap$ is.char.in.str
+  swap$ "oe" = or
+  swap$ "OE" = or
+  swap$ "ae" = or
+  swap$ "AE" = or
+  swap$ "aa" = or
+  swap$ "AA" = or
+}
+
+FUNCTION {map.char}
+{
+  't :=
+  split.first.char.from.str
+  { swap$ duplicate$ "" = not }
+    {
+      swap$ t =
+        { pop$ "" t }
+        {
+          swap$ split.first.char.from.str pop$ swap$
+          split.first.char.from.str
+        }
+      if$
+    }
+  while$
+  pop$ t =
+    'get.first.char.from.str
+    { pop$ t }
+  if$
+}
+
+FUNCTION {to.lower}
+{
+  duplicate$ is.upper.ascii
+    { chr.to.int$ #32 + int.to.chr$ }
+    { latin.lower swap$ latin.upper swap$ map.char }
+  if$
+}
+
+FUNCTION {to.upper}
+{
+  duplicate$ is.lower.ascii
+    { chr.to.int$ #32 - int.to.chr$ }
+    { latin.upper swap$ latin.lower swap$ map.char }
+  if$
+}
+
+FUNCTION {all.to.lower}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.lower swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.lower}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+          duplicate$ is.special.char.command
+            'all.to.lower
+            'skip$
+          if$
+        }
+        'to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.lower}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+        {
+          split.first.char.from.str
+          duplicate$ #92 int.to.chr$ =
+            {
+              swap$ skip.inter.token.command 't := * t
+              swap$ command.to.lower
+            }
+            'to.lower
+          if$
+          swap$ 't := * t
+        }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.lower
+      if$
+    }
+  if$
+}
+
+FUNCTION {all.to.upper}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    { split.first.char.from.str to.upper swap$ 't := * t }
+  while$
+  *
+}
+
+FUNCTION {command.to.upper}
+{
+  duplicate$ "" =
+    { "command.to.lower: Empty string is not a texchar!" warning$ }
+    {
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        {
+           duplicate$ is.special.char.command
+             'all.to.upper
+             'skip$
+           if$
+        }
+        'to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {tex.to.upper}
+{
+  duplicate$ #1 #2 substring$ "{" #92 int.to.chr$ * =
+    {
+      "" swap$
+      { duplicate$ "" = not }
+      {
+        split.first.char.from.str
+        duplicate$ #92 int.to.chr$ =
+          {
+            swap$ skip.inter.token.command 't := * t
+            swap$ command.to.upper
+          }
+          'to.upper
+        if$
+        swap$ 't := * t
+      }
+      while$
+      pop$
+    }
+    {
+      duplicate$ #1 #1 substring$ "{" =
+        { split.first.char.from.str swap$ find.match.brace pop$ }
+        'command.to.upper
+      if$
+    }
+  if$
+}
+
+FUNCTION {lower.token.if.in.title.case}
+{
+  duplicate$ is.tex.str.in.title.case
+    { split.first.tex.char.from.str tex.to.lower swap$ * }
+    'skip$
+  if$
+}
+
+FUNCTION {self.tokens}
+{
+  #0 =
+    'default.self.tokens
+    'range.delimiters
+  if$
+}
+
+FUNCTION {tokenize.by}
+{
+  'b :=
+  's :=
+
+  s "" =
+    { "" "" }
+    {
+      s split.first.char.from.str
+      duplicate$ b self.tokens swap$ is.char.in.str
+        'swap$
+        {
+          duplicate$ #92 int.to.chr$ =
+            { swap$ skip.inter.token.command 's := * s }
+            {
+              pop$ pop$ "" s
+              { duplicate$ "" = not }
+                {
+                  split.first.char.from.str
+                  duplicate$ "\ " b self.tokens * swap$ is.char.in.str
+                    { pop$ pop$ "" }
+                    {
+                      duplicate$ "{" =
+                        { swap$ find.match.brace }
+                        'swap$
+                      if$
+                      's := * s
+                    }
+                  if$
+                }
+              while$
+              pop$ s
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tokenize}
+{
+  #0 tokenize.by
+}
+
+FUNCTION {smart.sentence.case}
+{
+  tokenize 's :=
+
+  { s "" = not }
+    {
+      s skip.inter.token.chars 's := * s
+      tokenize swap$
+      duplicate$ ":" =
+        {
+          swap$ 's := *
+          s skip.inter.token.chars 's := * s
+          tokenize swap$
+          lowercase.word.after.colon
+            {
+              duplicate$ "A" =
+                { pop$ "a" }
+                'lower.token.if.in.title.case
+              if$
+            }
+            'skip$
+          if$
+        }
+        'lower.token.if.in.title.case
+      if$
+      swap$ 's := *
+    }
+  while$
+}
+
+FUNCTION {smart.upper.case}
+{
+  s swap$ t swap$
+
+  "" swap$
+  { duplicate$ "" = not }
+    {
+      tokenize swap$
+      duplicate$ #1 #1 substring$ #92 int.to.chr$ =
+        'command.to.upper
+        {
+          "" swap$
+          { duplicate$ "" = not }
+            {
+              split.first.tex.char.from.str tex.to.upper
+              swap$ 't := * t
+            }
+          while$
+          pop$
+        }
+      if$
+      swap$ 't := * t
+      skip.inter.token.chars 't := * t
+    }
+  while$
+  pop$
+
+  swap$ 't :=
+  swap$ 's :=
+}
+
 FUNCTION {field.or.null}
 { duplicate$ empty$
     { pop$ "" }
@@ -594,7 +1217,7 @@ FUNCTION {format.name}
       name.lang lang.en =
         { t #1 "{vv~}{ll}{ f{~}}" format.name$
           uppercase.name
-            { "u" change.case$ }
+            'smart.upper.case
             'skip$
           if$
           t #1 "{, jj}" format.name$ *
@@ -773,7 +1396,7 @@ FUNCTION {output.bibitem}
 
 FUNCTION {change.sentence.case}
 { entry.lang lang.en =
-    { "t" change.case$ }
+    'smart.sentence.case
     'skip$
   if$
 }
@@ -1383,32 +2006,27 @@ FUNCTION {format.urldate}
   if$
 }
 
-FUNCTION {hyphenate}
-{ 't :=
-  ""
-    { t empty$ not }
-    { t #1 #1 substring$ "-" =
-        { wave.dash.in.pages
-            { "～" * }
-            { "-" * }
-          if$
-            { t #1 #1 substring$ "-" = }
-            { t #2 global.max$ substring$ 't := }
-          while$
-        }
-        { t #1 #1 substring$ *
-          t #2 global.max$ substring$ 't :=
-        }
+FUNCTION {normalize.page.range}
+{
+  "" swap$
+  { duplicate$ empty$ not }
+    {
+      #1 skip.inter.token.chars.by 't :=
+      empty$
+        { "" }
+        'page.range.delimiter
       if$
+      * t
+      #1 tokenize.by 't :=
+      * t
     }
   while$
+  pop$
 }
 
 FUNCTION {format.pages}
-{ pages empty$
-    { "" }
-    { pages hyphenate }
-  if$
+{
+  pages normalize.page.range
 }
 
 FUNCTION {format.extracted.pages}
@@ -1416,8 +2034,8 @@ FUNCTION {format.extracted.pages}
     { "" }
     { pages
       only.start.page
-        'extract.before.dash
-        'hyphenate
+        { #1 tokenize.by pop$ }
+        'normalize.page.range
       if$
     }
   if$


### PR DESCRIPTION
This squashed commit basically fix issue [145][1] and 3 points mentioned in issue [172][2].  It now supports basic UTF-8 characters and perform proper case conversion for common latin letters with diacritics.  At the same time, it is backward compatible with most existing syntactics. Nothing can demonstrate this better than the following examples.

```
"200 \LaTeX \ae Foö{bar}{\'o \ae}{{\'o}}" smart.upper.case top$
"Perturbations in the A $\Sigma_u^+$ state of Na$_2$" smart.sentence.case top$
```

The above code produce `200 \LaTeX \AE FOÖ{bar}{\'O \AE}{{\'o}}` and `Perturbations in the A $\Sigma_u^+$ state of Na$_2$. {\H {c}a{d{e}}}o`. It mostly respects `x_change_case` procedure implemented in [_bibtex.web_][3].  One obvious difference is that commands (except those for single letters with diacritics) at brace level 0 won't undergo case transformation.  Brace protection is still honored.  For UTF-8 characters and simple math expression, you probably won't need them though, as indicated in the above example.

[1]: https://github.com/zepinglee/gbt7714-bibtex-style/issues/145
[2]: https://github.com/zepinglee/gbt7714-bibtex-style/issues/172#issuecomment-2494493432
[3]: https://tug.org/svn/texlive/trunk/Build/source/texk/web2c/bibtex.web?revision=57915&view=markup#l8884

Squashed commit of the following:

commit bc1574fd7837046a3749f7679a030bd1c47d19e0
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Mon Dec 2 10:46:11 2024 +0800

    Rewrite normalize.page.range again

commit b54d85655923f7fc119c778aca8297e84ea9ba9c
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Fri Nov 29 03:31:35 2024 +0800

    Rewrite normalize.page.range

commit bdb9fdd71388f3f03365d6bc70b3213b96ae148d
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Thu Nov 28 08:22:00 2024 +0800

    Implement functions for texchar semantics

commit a1d3f5b5feb9ae88e33919dd706e45a79fff178e
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Wed Nov 27 17:26:57 2024 +0800

    Support Latin Extended-A

commit 775f79716f553066983f1b7e4afef259b0335133
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Wed Nov 27 16:33:01 2024 +0800

    Implement smart.upper.case

commit 20bffbdb3d111f4f54f3769e7fe56a2c6d1959bb
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Sat Nov 23 00:46:39 2024 +0800

    Support polymorphism when tokenizing

commit 31ef32edcf181f070ebd7159377d2e3f52690952
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Thu Nov 21 21:57:27 2024 +0800

    Update tests for Dublin Core entry

commit 4abe6018a40192cbf8dceaa7f5a86f682aaeb279
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Thu Nov 21 09:08:03 2024 +0800

    Increase compatibility of font selection

commit aad1cb912de60169f6bb11c5d8dfbbd210545129
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Thu Nov 21 06:48:52 2024 +0800

    Use page.range.separator

    Rewrite `hyphenate` and rename it to `normalize.page.range`.  Use
    `page.range.separator` to configure separator in page ranges.  Also
    update DocStrip options for added or modifed configuration variables.

commit 0450382a41a47269646aaa9ad22f81d43125afad
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Thu Nov 21 04:49:56 2024 +0800

    Follow the existing convention

    Follow the convention of using function to define constants

commit cf3c5c662e8bd125fc5e3d41ca12a6de507c0f4a
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Thu Nov 21 02:06:25 2024 +0800

    Refactoring

     * Now `is.all.lower` returns true for empty strings.  Following the convention of modern predicate logic, it assumes no existential import.  Update functions which depend on it.

     * The second argument of the return value of `split.first.char.from.str`
       is of polymorphic type.  It returns an empty string for an empty
       string instead of a null char.

     * Some functions are rewritten to enable short-circuit evaluation.

commit 352b89ba29034ffe8b1a6d45beddba7365215de3
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Wed Nov 20 19:30:07 2024 +0800

    Do some refactoring and renaming

commit bbf5add59a0cf7b620d737f87081f01830bfbceb
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Wed Nov 20 07:57:18 2024 +0800

    Enable lowercase.word.after.colon by default

    Also update tests for this

commit 6a7c3bc1b4ceafd3a0a14fe480e9a32a3445d01c
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Wed Nov 20 07:49:36 2024 +0800

    Update tests for smart.sentence.case

commit b3c9d79617e7f0fa761964872dddbc6b2fca7779
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Wed Nov 20 06:40:38 2024 +0800

    Add basic UTF-8 support

commit 456687e162eee4c480b9bd9adac31de964ae912a
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Sat Nov 16 05:53:13 2024 +0800

    Remove ignore.extra.interword.space

    This feature is extraneous since the extra spaces are already
    preprocessed by the BibTeX.

commit b15d6737f82ae87695a998fc7cd7bf2035b50683
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Thu Nov 14 20:33:20 2024 +0800

    Improve smart.sentence.case.lower.token

commit d7e7f532b6489556425275c57a0fd3bbfbecc330
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Thu Nov 14 19:18:29 2024 +0800

    Basically finish the smart lowercase feature

commit 5da7b113abbae12370ef1ebe1a1f5d347c617e6c
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Mon Nov 11 22:22:24 2024 +0800

    Update the source dtx file

commit dc88ba834c43ea88e48c04cf2e8c2dd959a1af23
Author: Lei Zhao <LeiZh26@gmail.com>
Date:   Mon Nov 11 20:38:39 2024 +0800

    Add en.dash.in.pages option

    Also process UTF-8 en dash (–)